### PR TITLE
fix: resolve 8 unreported bugs in jarvis_launcher.py and browserClient.py

### DIFF
--- a/browserClient.py
+++ b/browserClient.py
@@ -1,5 +1,5 @@
 """
-claudeBot.py — Browser automation client for the Toingg personal AI assistant.
+browserClient.py — Browser automation client for the Toingg personal AI assistant.
 
 Connects to the backend WebSocket, receives Playwright-compatible commands from the LLM,
 executes them in a real browser, and returns results.
@@ -166,18 +166,37 @@ class BrowserClient:
 
     @staticmethod
     def _repair_selector(selector: str) -> str:
-        """Repair common unescaped Tailwind class selectors like button.p-2.5."""
+        """Repair unescaped Tailwind class selectors like button.p-2.5 or button.p-2.5.flex.
+
+        CSS parsers treat 'button.p-2.5' as two classes ('p-2' and '5'), but the Tailwind
+        class is a single token 'p-2.5'. This converts each class to [class~="token"] so
+        multi-class selectors like 'button.p-2.5.flex' become
+        'button[class~="p-2.5"][class~="flex"]' and still match correctly.
+        """
         if "," in selector or " " in selector or "[" in selector or "#" in selector:
             return selector
         parts = selector.split(".")
         if len(parts) <= 2:
             return selector
         tag = parts[0]
-        class_name = ".".join(parts[1:])
-        if not tag or not class_name:
+        if not tag:
             return selector
-        escaped_class = class_name.replace("\\", "\\\\").replace('"', '\\"')
-        return f'{tag}[class~="{escaped_class}"]'
+
+        # Re-merge decimal suffixes: ["p-2", "5"] → "p-2.5"
+        classes: list[str] = []
+        for part in parts[1:]:
+            if not part:
+                continue
+            if classes and part.isdigit():
+                classes[-1] += "." + part
+            else:
+                classes.append(part)
+
+        if not classes:
+            return selector
+
+        escaped = [c.replace("\\", "\\\\").replace('"', '\\"') for c in classes]
+        return tag + "".join(f'[class~="{c}"]' for c in escaped)
 
     @staticmethod
     def _preview_text(value: str | None, limit: int = 120) -> str:
@@ -1182,7 +1201,7 @@ class BrowserClient:
     def _on_message(self, ws, raw: str):
         try:
             msg = json.loads(raw)
-            print("Received: ", msg)
+            log.debug("Received: %s", msg)
         except json.JSONDecodeError:
             return
 

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -632,7 +632,7 @@ def find_running_pid(exe_name):
     try:
         out = subprocess.check_output(
             ["tasklist", "/FI", f"IMAGENAME eq {exe_name}", "/FO", "CSV", "/NH"],
-            shell=True, stderr=subprocess.DEVNULL
+            shell=False, stderr=subprocess.DEVNULL
         ).decode(errors="ignore")
         for line in out.strip().splitlines():
             parts = line.strip('"').split('","')
@@ -643,6 +643,8 @@ def find_running_pid(exe_name):
     return None
 
 def focus_window_by_exe(exe_name, rect):
+    if _plat.system() != "Windows":
+        return False
     user32 = ctypes.windll.user32
     EnumWindowsProc = ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
     found = []
@@ -672,6 +674,8 @@ def focus_window_by_exe(exe_name, rect):
     return False
 
 def resize_window_by_pid(pid, rect, retries=20, interval=0.5):
+    if _plat.system() != "Windows":
+        return
     user32 = ctypes.windll.user32
     EnumWindowsProc = ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
     def find_hwnd():
@@ -682,10 +686,6 @@ def resize_window_by_pid(pid, rect, retries=20, interval=0.5):
             win_pid = ctypes.wintypes.DWORD(0)
             user32.GetWindowThreadProcessId(hwnd, ctypes.byref(win_pid))
             if win_pid.value == pid:
-                found.append(hwnd); return False
-            buf = ctypes.create_unicode_buffer(256)
-            user32.GetWindowTextW(hwnd, buf, 256)
-            if 'spotify' in buf.value.lower():
                 found.append(hwnd); return False
             return True
         user32.EnumWindows(EnumWindowsProc(cb), 0)
@@ -708,15 +708,19 @@ def open_app(name):
             "vs code": "Visual Studio Code", "vscode": "Visual Studio Code",
             "code": "Visual Studio Code", "visual studio code": "Visual Studio Code",
             "spotify": "Spotify", "chrome": "Google Chrome", "firefox": "Firefox",
+            "terminal": "Terminal", "calculator": "Calculator",
+            "notepad": "TextEdit", "explorer": "Finder",
         }
         app = mac_names.get(name)
-        if app:
+        candidates = [app] if app else [name.title(), name]
+        for candidate in candidates:
             try:
-                subprocess.Popen(["open", "-a", app])
+                subprocess.Popen(["open", "-a", candidate])
                 print(f"  [app] ✅ Launched {name}")
                 return True
-            except Exception as e:
-                print(f"  [app] ⚠  Mac open failed: {e}")
+            except Exception:
+                pass
+        print(f"  [app] ✗ Could not open: {name}")
         return False
 
     paths    = APPS.get(name, [])
@@ -806,15 +810,18 @@ def voice_listener():
     recognizer.non_speaking_duration    = 0.8
     recognizer.phrase_threshold         = 0.3
     print("  [voice] 🎙  Listening for: hey jarvis / jarvis...")
+    mic = sr.Microphone(sample_rate=16000)
 
     while True:
         if stop_capture.is_set():
             print("  [voice] ⏸  Mic paused. Press Enter to resume...")
-            input()
+            try:
+                input()
+            except (EOFError, KeyboardInterrupt):
+                pass
             stop_capture.clear()
             print("  [voice] ▶  Resumed.\n")
         try:
-            mic = sr.Microphone(sample_rate=16000)
             with mic as source:
                 recognizer.adjust_for_ambient_noise(source, duration=0.5)
             with mic as source2:


### PR DESCRIPTION
## Summary

This PR fixes 8 bugs discovered through code review that had no existing issues. Each fix is linked to its newly-opened issue.

### browserClient.py

- **Wrong module name in docstring** — `claudeBot.py` → `browserClient.py` (closes #14)
- **Debug print leaks all WebSocket payloads to stdout** — replaced `print("Received: ", msg)` with `log.debug(...)` so message content is suppressed at default log level (closes #15)
- **`_repair_selector` breaks for multi-class Tailwind selectors** — `button.p-2.5.flex` was repaired to `button[class~="p-2.5.flex"]` which never matches anything; now merges numeric decimal suffixes and emits one `[class~="token"]` per class: `button[class~="p-2.5"][class~="flex"]` (closes #16)

### jarvis_launcher.py

- **`find_running_pid` silently drops all tasklist filter flags** — `subprocess.check_output(list, shell=True)` on Windows only passes `args[0]` to the shell; changed to `shell=False` (closes #17)
- **`focus_window_by_exe` and `resize_window_by_pid` crash on macOS/Linux** — both called `ctypes.windll.user32` with no platform guard; added `if platform.system() != "Windows": return` early exit (closes #18)
- **Hardcoded `'spotify'` fallback in `resize_window_by_pid` could resize the wrong window** — when Spotify was open and the PID match hadn't fired yet, any other app resize would accidentally focus Spotify instead; removed the title-based fallback (closes #19)
- **`open_app` silently fails on macOS for `chrome`, `firefox`, `terminal`, `calculator`, etc.** — added missing mappings (`Terminal`, `Calculator`, `TextEdit`, `Finder`) and a generic `open -a name.title()` fallback (closes #20)
- **`voice_listener` crashes with `EOFError` when launched without a terminal** — `input()` raises immediately on a non-TTY stdin (e.g. double-click launch), permanently killing the listener thread; wrapped in `try/except (EOFError, KeyboardInterrupt)` (closes #21)
- **`sr.Microphone` re-created on every listen cycle** — moved construction outside the `while True:` loop to avoid reopening the audio device on every 8-second iteration (closes #22)

## Test plan

- [ ] Windows: say "open spotify" with Spotify already running — verify it focuses, not the wrong window
- [ ] Windows: say "open vs code" with Spotify open in background — verify VS Code is focused, not Spotify
- [ ] macOS: say "open terminal" / "open calculator" — verify they launch
- [ ] Launch via double-click (no terminal): verify voice listener survives after first wake-word trigger
- [ ] Trigger a Playwright click with a multi-class Tailwind selector like `button.p-2.5.flex` — verify it resolves correctly
- [ ] Check that no raw WebSocket message JSON appears on stdout during browser automation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)