### PR TITLE
feat: add native file manager integration

### DIFF
--- a/JARVIS_README.md
+++ b/JARVIS_README.md
@@ -96,7 +96,21 @@ CAMP_ID = "your-campaign-id-here"
 - Press **Enter** to speak — JARVIS listens and responds via audio
 - When JARVIS fetches news/weather/war updates, browser tabs open automatically in a 2×2 grid
 - JARVIS can open specific URLs, scrape article details, and close tabs on command
+- JARVIS can open folders, reveal local files, and open files through the native file manager (`/file_action`)
 - Press **Ctrl+C** to stop
+
+### Native file manager commands
+
+When the launcher is running, the web UI can call the local bridge:
+
+```http
+POST http://localhost:8766/file_action
+Content-Type: application/json
+
+{ "action": "reveal_file", "path": "/path/to/file.txt" }
+```
+
+Supported actions are `open_directory`, `open_file`, and `reveal_file` / `show_in_folder`. The bridge validates that the target exists, then uses Finder on macOS, Explorer on Windows, or the available Linux opener (`xdg-open` / `gio`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,26 @@ All three layers run simultaneously and communicate over `localhost:8766`.
 
 </td>
 </tr>
+<tr>
+<td width="50%">
+
+**🗂️ Native File Manager**
+- Open folders in Finder / Explorer / Linux file manager
+- Reveal a specific file in its containing folder
+- Open local files with the platform default app
+- Safe JSON endpoint with path validation and clear errors
+
+</td>
+<td width="50%">
+
+**🔌 Local Tool Bridge**
+- `POST /file_action` accepts `open_file`, `open_directory`, or `reveal_file`
+- WebSocket events such as `open_file` and `show_in_folder` trigger the bridge
+- No shell-string execution; commands are launched as argument lists
+- Falls back to clickable browser links for URL actions
+
+</td>
+</tr>
 </table>
 
 ---
@@ -370,9 +390,31 @@ python3 jarvis_launcher.py
 | Say **"open Spotify"** | Launches Spotify |
 | Say **"open Chrome"** | Launches Chrome |
 | Say **"open VS Code"** | Launches Visual Studio Code |
+| Assistant sends `open_directory` / `open_file` / `reveal_file` | Opens Finder, Explorer, or the Linux file manager |
 | **Ctrl+C** in terminal | Exit JARVIS |
 
 When JARVIS fetches news, weather, or web results — Chrome windows open automatically in a **2×2 grid** and close after the response finishes.
+
+### Native file-manager actions
+
+The local launcher exposes a small file bridge for assistant commands:
+
+```http
+POST http://localhost:8766/file_action
+Content-Type: application/json
+
+{ "action": "open_directory", "path": "~/Downloads" }
+```
+
+Supported actions:
+
+| Action | Behavior |
+|--------|----------|
+| `open_directory` | Opens the folder in Finder / Explorer / Linux file manager. Empty path defaults to the user's home folder. |
+| `open_file` | Opens an existing file with the operating system's default application. |
+| `reveal_file` / `show_in_folder` | Reveals a file in its containing folder (`open -R` on macOS, `explorer /select` on Windows, parent folder on Linux). |
+
+The web UI also handles matching WebSocket events, so a backend message such as `{"event":"reveal_file","path":"/path/to/file.txt"}` will call the local bridge.
 
 ---
 

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -12,7 +12,7 @@ Requirements:
     pip install sounddevice numpy speechrecognition
 """
 
-import os, sys, time, threading, subprocess, tempfile, json, webbrowser
+import os, sys, time, threading, subprocess, tempfile, json, webbrowser, shutil
 import ctypes, ctypes.wintypes
 import platform as _plat
 
@@ -24,6 +24,21 @@ BROWSER_CLIENT = os.path.join(_DIR, "browserClient.py")
 WAKE_WORDS  = ["hey jarvis", "jarvis", "hey jervis", "hey davis"]
 LAUNCH_COOLDOWN = 4.0
 HTTP_PORT   = 8766
+
+FILE_ACTION_ALIASES = {
+    "open": "open_file",
+    "open_file": "open_file",
+    "file": "open_file",
+    "open_directory": "open_directory",
+    "open_dir": "open_directory",
+    "open_folder": "open_directory",
+    "folder": "open_directory",
+    "directory": "open_directory",
+    "reveal": "reveal_file",
+    "reveal_file": "reveal_file",
+    "show_in_folder": "reveal_file",
+    "show_in_finder": "reveal_file",
+}
 
 # ── shared state (jarvis_web.html POSTs here; jarvis_visual.html polls here) ─
 _http_state      = {"state": "initializing", "text": "", "status": "INITIALIZING..."}
@@ -228,6 +243,86 @@ def get_active_screen_bounds():
             pass
 
     return None
+
+def normalize_file_action(action):
+    """Return the canonical native file-manager action name."""
+    action = str(action or "open_directory").strip().lower().replace("-", "_")
+    if action not in FILE_ACTION_ALIASES:
+        allowed = ", ".join(sorted(set(FILE_ACTION_ALIASES.values())))
+        raise ValueError(f"unsupported file action '{action}'. Allowed: {allowed}")
+    return FILE_ACTION_ALIASES[action]
+
+def resolve_local_file_path(path, action="open_directory"):
+    """Expand and validate a user-supplied local path for native file actions."""
+    action = normalize_file_action(action)
+    if not path:
+        if action == "open_directory":
+            path = "~"
+        else:
+            raise ValueError("path is required for this file action")
+    if not isinstance(path, str):
+        raise ValueError("path must be a string")
+
+    resolved = os.path.abspath(os.path.expandvars(os.path.expanduser(path.strip())))
+    if not os.path.exists(resolved):
+        raise FileNotFoundError(f"path does not exist: {resolved}")
+    return resolved
+
+def _linux_open_command(path):
+    for candidate in ("xdg-open", "gio", "gnome-open", "kde-open"):
+        found = shutil.which(candidate)
+        if found:
+            return [found, "open", path] if candidate == "gio" else [found, path]
+    raise RuntimeError("no Linux file opener found (install xdg-utils or gio)")
+
+def build_native_file_command(action, path, system=None):
+    """Build the platform-native command used to open/reveal a local path."""
+    action = normalize_file_action(action)
+    system = system or _plat.system()
+    is_dir = os.path.isdir(path)
+
+    if action == "open_directory" and not is_dir:
+        path = os.path.dirname(path)
+        is_dir = True
+
+    if system == "Darwin":
+        if action == "reveal_file":
+            return ["open", "-R", path]
+        return ["open", path]
+
+    if system == "Windows":
+        if action == "open_file" and not is_dir:
+            return ["startfile", path]
+        if action == "reveal_file" and not is_dir:
+            return ["explorer", f"/select,{path}"]
+        return ["explorer", path]
+
+    if action == "reveal_file" and not is_dir:
+        path = os.path.dirname(path)
+    return _linux_open_command(path)
+
+def run_file_action(payload):
+    """Open a file, open a directory, or reveal a file in the OS file manager."""
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be a JSON object")
+
+    action = normalize_file_action(payload.get("action") or payload.get("type"))
+    path = payload.get("path") or payload.get("file") or payload.get("directory")
+    path = resolve_local_file_path(path, action)
+    command = build_native_file_command(action, path)
+
+    if command[0] == "startfile":
+        os.startfile(command[1])  # type: ignore[attr-defined]
+    else:
+        subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    return {
+        "ok": True,
+        "action": action,
+        "path": path,
+        "platform": _plat.system(),
+        "command": command[0],
+    }
 
 def top_center_near_active_window(win_w):
     """Place a window at the top of the same display area as the active app."""
@@ -613,6 +708,24 @@ def start_http_server():
                 self._cors()
                 self.end_headers()
                 self.wfile.write(b'{"ok":true}')
+
+            elif self.path == "/file_action":
+                try:
+                    payload = json.loads(body) if body else {}
+                    result = run_file_action(payload)
+                    print(f"  [files] ✅ {result['action']} → {result['path']}")
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(json.dumps(result).encode())
+                except Exception as e:
+                    print(f"  [files] ⚠  file_action error: {e}")
+                    self.send_response(400)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"ok": False, "error": str(e)}).encode())
 
             elif self.path == "/config":
                 try:

--- a/jarvis_web.html
+++ b/jarvis_web.html
@@ -925,6 +925,37 @@ const SERVER = "http://localhost:8766";
 const urlBarEl    = document.getElementById("url-bar");
 const urlLinksEl  = document.getElementById("url-links");
 
+function normalizeFileActionMessage(msg = {}) {
+  const ev = String(msg.event || msg.type || "").trim().toLowerCase();
+  const action = String(msg.action || ev || "open_directory")
+    .trim()
+    .toLowerCase()
+    .replace(/-/g, "_");
+  return {
+    action,
+    path: msg.path || msg.file || msg.directory || "",
+    label: msg.label || msg.title || msg.path || msg.file || msg.directory || action,
+  };
+}
+
+async function runNativeFileAction(msg = {}) {
+  const payload = normalizeFileActionMessage(msg);
+  try {
+    const res = await fetch(`${SERVER}/file_action`, {
+      method:  "POST",
+      headers: { "Content-Type": "application/json" },
+      body:    JSON.stringify(payload),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || data.ok === false) throw new Error(data.error || `HTTP ${res.status}`);
+    logChat("sys", `◈ FILE ACTION: ${payload.action} — ${payload.label}`);
+    return true;
+  } catch (err) {
+    logChat("sys", `◈ FILE ACTION FAILED: ${payload.action} — ${err.message || err}`);
+    return false;
+  }
+}
+
 function isCampaignDashboardLabel(label) {
   return String(label || "").trim().toLowerCase() === "campaign dashboard";
 }
@@ -1496,6 +1527,16 @@ function connectWs() {
         logChat("sys", `◈ OPEN TAB: ${label.slice(0, 60)} — queued`);
         showUrlBar(pendingUrls);  // refresh bar with all pending
       }
+
+    } else if (
+      ev === "file_action" ||
+      ev === "open_file" ||
+      ev === "open_directory" ||
+      ev === "open_folder" ||
+      ev === "reveal_file" ||
+      ev === "show_in_folder"
+    ) {
+      runNativeFileAction({ ...msg, action: msg.action || ev });
 
     } else if (ev === "close_all_tabs") {
       const types = msg.tab_types || ["all"];

--- a/test_file_manager.py
+++ b/test_file_manager.py
@@ -1,0 +1,39 @@
+import os
+import tempfile
+import unittest
+
+from jarvis_launcher import (
+    build_native_file_command,
+    normalize_file_action,
+    resolve_local_file_path,
+)
+
+
+class NativeFileManagerTests(unittest.TestCase):
+    def test_action_aliases_are_canonical(self):
+        self.assertEqual(normalize_file_action("open-folder"), "open_directory")
+        self.assertEqual(normalize_file_action("show_in_folder"), "reveal_file")
+        self.assertEqual(normalize_file_action("file"), "open_file")
+
+    def test_resolve_default_directory_uses_home(self):
+        resolved = resolve_local_file_path("", "open_directory")
+        self.assertEqual(resolved, os.path.abspath(os.path.expanduser("~")))
+
+    def test_rejects_missing_paths(self):
+        with self.assertRaises(FileNotFoundError):
+            resolve_local_file_path("/definitely/missing/jarvis-file.txt", "open_file")
+
+    def test_macos_reveal_uses_open_dash_r(self):
+        with tempfile.NamedTemporaryFile() as tmp:
+            command = build_native_file_command("reveal_file", tmp.name, system="Darwin")
+        self.assertEqual(command[:2], ["open", "-R"])
+
+    def test_windows_reveal_uses_explorer_select(self):
+        with tempfile.NamedTemporaryFile() as tmp:
+            command = build_native_file_command("reveal_file", tmp.name, system="Windows")
+        self.assertEqual(command[0], "explorer")
+        self.assertTrue(command[1].startswith("/select,"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #9

## Linked Issue
Closes #9

## Summary of Changes
- Added a cross-platform native file-manager bridge at `POST /file_action` for `open_directory`, `open_file`, and `reveal_file` / `show_in_folder` actions.
- Wired matching web UI WebSocket events (`open_file`, `open_directory`, `open_folder`, `reveal_file`, `show_in_folder`) to call the local launcher bridge.
- Added safe path expansion/validation, platform-specific command construction for macOS/Windows/Linux, and docs for the new assistant file actions.
- Added lightweight unit tests for action aliases, path validation, and platform command generation.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / tooling / config change

## Testing Performed
- [ ] Tested on **Windows**
- [x] Tested on **macOS**
- [ ] Tested on **Linux**
- Platform tested on: macOS (local)
- Python version: Python 3.13

Steps to verify:
1. `python3 -m unittest test_file_manager.py`
2. `python3 -m py_compile jarvis_launcher.py browserClient.py`
3. Review `/file_action` docs in `README.md`.

## Screenshots / Recordings
Not applicable; this is a local launcher/web-event bridge.

## Reward Points Requested
Points requested: **100**
Justification: requested small/medium new feature with cross-platform support and tests.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented non-obvious logic
- [x] I have updated relevant documentation
- [x] My changes do not introduce new warnings or errors
- [x] I have tested this on at least one supported platform
- [x] I have not committed secrets, API keys, or personal config files
