### PR TITLE
ci: add cross-platform packaging scaffold

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,0 +1,42 @@
+# Packaging J.A.R.V.I.S
+
+This repository includes a packaging scaffold for creating user-friendly release artifacts on Windows, macOS, and Linux.
+
+## Local build
+
+```bash
+python -m pip install -r requirements.txt pyinstaller
+python -m playwright install chromium
+python -m PyInstaller packaging/pyinstaller/JARVIS.spec --noconfirm --clean
+```
+
+The PyInstaller output is written to `dist/JARVIS/`.
+
+## macOS `.app`
+
+```bash
+python packaging/macos/make_app.py dist/JARVIS/JARVIS dist/JARVIS.app
+```
+
+The generated app bundle includes microphone permission metadata. Maintainers can later add signing and notarization before public distribution.
+
+## Linux `.deb`
+
+```bash
+VERSION=0.1.0 bash packaging/linux/make_deb.sh dist/JARVIS dist/packages
+```
+
+This creates `dist/packages/jarvis_0.1.0_amd64.deb` and links `/usr/bin/jarvis` to the installed launcher.
+
+## Windows installer
+
+The workflow always uploads a Windows zip. If Inno Setup is available on the runner, `packaging/windows/JARVIS.iss` can build `JARVIS-Setup.exe` from `dist/JARVIS/`.
+
+## GitHub Actions release flow
+
+Copy `packaging/github-actions/package.yml` to `.github/workflows/package.yml` in a branch with workflow-write permissions. The `Package JARVIS` workflow runs on:
+
+- manual `workflow_dispatch`
+- version tags matching `v*`
+
+It builds an OS matrix and uploads artifacts for each runner. Signing and notarization are intentionally left as maintainer-controlled steps because they require private certificates and should not be stored in the repository.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 - [📄 Data Requirements](#-data-requirements)
 - [🔧 Configuration](#-configuration)
 - [🗂️ Project Structure](#️-project-structure)
+- [📦 Packaging](#-packaging)
 - [🧠 Methodology](#-methodology)
 - [⚡ Performance](#-performance)
 - [🧪 Testing](#-testing)
@@ -431,10 +432,29 @@ toingg-jarvis/
 ├── 🎨 jarvis_visual.html      # Animated orb / visual display
 ├── 🖥️  JARVIS.bat              # Windows auto-installer & launcher
 ├── 🍎 JARVIS.command          # macOS auto-installer & launcher
+├── 📦 packaging/              # PyInstaller, .app, .deb, and Windows installer helpers
+├── ⚙️  packaging/github-actions/ # GitHub Actions release workflow template
+├── 📄 PACKAGING.md            # Maintainer release packaging guide
+├── 📄 requirements.txt        # Shared Python dependencies for install/build
 ├── 🔧 setup_mac.sh            # macOS one-time permission fixer
 ├── 📄 config.json             # API credentials (create from example, not committed)
 └── 📄 config.example.json     # Config template
 ```
+
+---
+
+## 📦 Packaging
+
+Maintainers can build release artifacts with the included packaging scaffold:
+
+- `requirements.txt` defines shared runtime/build dependencies.
+- `packaging/pyinstaller/JARVIS.spec` creates the cross-platform PyInstaller build.
+- `packaging/macos/make_app.py` wraps the launcher in a minimal `.app` bundle with microphone permission metadata.
+- `packaging/linux/make_deb.sh` turns the PyInstaller output into a Debian/Ubuntu `.deb`.
+- `packaging/windows/JARVIS.iss` provides an Inno Setup template for a Windows installer.
+- `packaging/github-actions/package.yml` is a GitHub Actions template that builds artifacts on tags matching `v*` or manual workflow dispatch.
+
+See [`PACKAGING.md`](PACKAGING.md) for the full release workflow and where to install the workflow template.
 
 ---
 

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -12,7 +12,7 @@ Requirements:
     pip install sounddevice numpy speechrecognition
 """
 
-import os, sys, time, threading, subprocess, tempfile, json, webbrowser
+import os, sys, time, threading, subprocess, tempfile, json, webbrowser, runpy
 import ctypes, ctypes.wintypes
 import platform as _plat
 
@@ -385,7 +385,11 @@ def start_browser_client():
         print("  [browser] ⚠  browserClient.py not found"); return
 
     try:
-        _browser_client_proc = subprocess.Popen([sys.executable, BROWSER_CLIENT], cwd=_DIR)
+        if getattr(sys, "frozen", False):
+            cmd = [sys.executable, "--browser-client"]
+        else:
+            cmd = [sys.executable, BROWSER_CLIENT]
+        _browser_client_proc = subprocess.Popen(cmd, cwd=_DIR)
         print("  [browser] ✅ browserClient.py started")
     except Exception as e:
         print(f"  [browser] ⚠  Failed to start browserClient.py: {e}")
@@ -1013,4 +1017,7 @@ def main():
         print("\n  Stopped.")
 
 if __name__ == "__main__":
-    main()
+    if len(sys.argv) > 1 and sys.argv[1] == "--browser-client":
+        runpy.run_path(BROWSER_CLIENT, run_name="__main__")
+    else:
+        main()

--- a/packaging/github-actions/package.yml
+++ b/packaging/github-actions/package.yml
@@ -1,0 +1,92 @@
+name: Package JARVIS
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build ${{ matrix.os }} artifact
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev dpkg-dev
+
+      - name: Install macOS system dependencies
+        if: runner.os == 'macOS'
+        run: brew install portaudio
+
+      - name: Install Windows installer toolchain
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: choco install innosetup --no-progress -y
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pyinstaller
+
+      - name: Install Playwright browser
+        run: python -m playwright install chromium
+
+      - name: Build PyInstaller app
+        run: python -m PyInstaller packaging/pyinstaller/JARVIS.spec --noconfirm --clean
+
+      - name: Package Windows zip
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path dist/JARVIS/* -DestinationPath dist/JARVIS-windows.zip -Force
+
+      - name: Package Windows installer when Inno Setup is available
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          if (Test-Path $iscc) {
+            & $iscc packaging/windows/JARVIS.iss
+            New-Item -ItemType Directory -Force -Path dist/packages | Out-Null
+            Copy-Item packaging/windows/Output/JARVIS-Setup.exe dist/packages/JARVIS-Setup.exe
+          } else {
+            Write-Host "Inno Setup not found; zip artifact still available."
+          }
+
+      - name: Package macOS app
+        if: runner.os == 'macOS'
+        run: |
+          python packaging/macos/make_app.py dist/JARVIS/JARVIS dist/JARVIS.app
+          ditto -c -k --sequesterRsrc --keepParent dist/JARVIS.app dist/JARVIS-macos-app.zip
+
+      - name: Package Linux deb
+        if: runner.os == 'Linux'
+        run: |
+          VERSION=${GITHUB_REF_NAME#v} bash packaging/linux/make_deb.sh dist/JARVIS dist/packages
+          tar -czf dist/JARVIS-linux.tar.gz -C dist JARVIS
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jarvis-${{ runner.os }}
+          path: |
+            dist/JARVIS-*.zip
+            dist/JARVIS-linux.tar.gz
+            dist/packages/*
+          if-no-files-found: warn

--- a/packaging/linux/make_deb.sh
+++ b/packaging/linux/make_deb.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="${1:-dist/JARVIS}"
+OUT_DIR="${2:-dist/packages}"
+VERSION="${VERSION:-0.1.0}"
+PKG_ROOT="${OUT_DIR}/jarvis_${VERSION}_amd64"
+
+if [[ ! -x "${APP_DIR}/JARVIS" ]]; then
+  echo "Expected executable at ${APP_DIR}/JARVIS" >&2
+  exit 1
+fi
+
+rm -rf "${PKG_ROOT}"
+mkdir -p "${PKG_ROOT}/DEBIAN" "${PKG_ROOT}/opt/jarvis" "${PKG_ROOT}/usr/bin"
+cp -R "${APP_DIR}/." "${PKG_ROOT}/opt/jarvis/"
+ln -s /opt/jarvis/JARVIS "${PKG_ROOT}/usr/bin/jarvis"
+
+cat > "${PKG_ROOT}/DEBIAN/control" <<EOF2
+Package: jarvis
+Version: ${VERSION}
+Section: utils
+Priority: optional
+Architecture: amd64
+Maintainer: PG-AGI <admin@pgagi.in>
+Depends: google-chrome-stable | chromium-browser | chromium | microsoft-edge-stable
+Description: J.A.R.V.I.S desktop voice assistant launcher
+ A packaged build of the JARVIS local launcher, visual UI, and browser automation helper.
+EOF2
+
+dpkg-deb --build "${PKG_ROOT}"
+echo "Created ${PKG_ROOT}.deb"

--- a/packaging/macos/make_app.py
+++ b/packaging/macos/make_app.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Create a minimal macOS .app bundle around the PyInstaller JARVIS executable."""
+
+from __future__ import annotations
+
+import argparse
+import plistlib
+import shutil
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build JARVIS.app from a PyInstaller executable")
+    parser.add_argument("executable", type=Path, help="Path to dist/JARVIS/JARVIS")
+    parser.add_argument("app", type=Path, nargs="?", default=Path("dist/JARVIS.app"))
+    args = parser.parse_args()
+
+    executable = args.executable.resolve()
+    if not executable.exists():
+        raise SystemExit(f"Executable not found: {executable}")
+
+    app = args.app.resolve()
+    contents = app / "Contents"
+    macos = contents / "MacOS"
+    resources = contents / "Resources"
+    if app.exists():
+        shutil.rmtree(app)
+    macos.mkdir(parents=True)
+    resources.mkdir(parents=True)
+
+    target = macos / "JARVIS"
+    shutil.copy2(executable, target)
+    target.chmod(0o755)
+
+    plist = {
+        "CFBundleName": "JARVIS",
+        "CFBundleDisplayName": "J.A.R.V.I.S",
+        "CFBundleIdentifier": "in.pgagi.jarvis",
+        "CFBundleVersion": "1.0.0",
+        "CFBundleShortVersionString": "1.0.0",
+        "CFBundleExecutable": "JARVIS",
+        "CFBundlePackageType": "APPL",
+        "LSMinimumSystemVersion": "10.15",
+        "NSMicrophoneUsageDescription": "JARVIS listens for wake words and voice commands.",
+    }
+    with (contents / "Info.plist").open("wb") as f:
+        plistlib.dump(plist, f)
+
+    print(f"Created {app}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/pyinstaller/JARVIS.spec
+++ b/packaging/pyinstaller/JARVIS.spec
@@ -1,0 +1,66 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for the J.A.R.V.I.S desktop launcher."""
+
+from pathlib import Path
+
+ROOT = Path.cwd()
+
+DATA_FILES = [
+    (str(ROOT / "jarvis_web.html"), "."),
+    (str(ROOT / "jarvis_visual.html"), "."),
+    (str(ROOT / "browserClient.py"), "."),
+    (str(ROOT / "config.example.json"), "."),
+    (str(ROOT / "README.md"), "."),
+    (str(ROOT / "JARVIS_README.md"), "."),
+]
+
+HIDDEN_IMPORTS = [
+    "speech_recognition",
+    "websocket",
+    "playwright.sync_api",
+    "playwright_stealth",
+]
+
+
+a = Analysis(
+    [str(ROOT / "jarvis_launcher.py")],
+    pathex=[str(ROOT)],
+    binaries=[],
+    datas=DATA_FILES,
+    hiddenimports=HIDDEN_IMPORTS,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="JARVIS",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="JARVIS",
+)

--- a/packaging/windows/JARVIS.iss
+++ b/packaging/windows/JARVIS.iss
@@ -1,0 +1,30 @@
+#define MyAppName "J.A.R.V.I.S"
+#define MyAppVersion "0.1.0"
+#define MyAppPublisher "PG-AGI"
+#define MyAppExeName "JARVIS.exe"
+
+[Setup]
+AppId={{AA32BC9A-7F1D-49DE-A88D-98713E6E0913}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+DefaultDirName={autopf}\JARVIS
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+OutputBaseFilename=JARVIS-Setup
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+
+[Files]
+Source: "..\..\dist\JARVIS\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription: "Additional icons:"
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "Launch {#MyAppName}"; Flags: nowait postinstall skipifsilent

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy>=1.24
+PyAudio>=0.2.14
+SpeechRecognition>=3.10
+websocket-client>=1.7
+playwright>=1.44
+playwright-stealth>=2.0
+rich>=13.7
+pyobjc-framework-Cocoa>=10.0; platform_system == "Darwin"


### PR DESCRIPTION
/claim #13

## Linked Issue
Closes #13

## Summary of Changes
- Added a practical cross-platform packaging scaffold for JARVIS:
  - shared `requirements.txt`
  - PyInstaller spec for `jarvis_launcher.py`
  - macOS `.app` bundling helper
  - Linux `.deb` packaging helper
  - Windows Inno Setup installer template
  - GitHub Actions workflow template for Windows/macOS/Linux release artifacts
- Updated `jarvis_launcher.py` so packaged/frozen builds can start `browserClient.py` via `--browser-client` instead of trying to spawn a separate Python script with a missing interpreter.
- Added `PACKAGING.md` plus README project-structure/release notes.

Note: the workflow file is included as `packaging/github-actions/package.yml` because my current GitHub token cannot write active `.github/workflows/*` files without the `workflow` scope. Maintainers can copy it to `.github/workflows/package.yml` after review.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor / code cleanup
- [x] CI / tooling / config change

## Testing Performed
- [ ] Tested on **Windows**
- [x] Tested on **macOS**
- [ ] Tested on **Linux**
- Platform tested on: macOS (local)
- Python version: Python 3.13

Steps to verify:
1. `python3 -m py_compile jarvis_launcher.py browserClient.py packaging/macos/make_app.py`
2. `bash -n packaging/linux/make_deb.sh`
3. `ruby -e "require 'yaml'; YAML.load_file('packaging/github-actions/package.yml'); puts 'workflow template yaml ok'"`
4. `git diff --check`

## Screenshots / Recordings
Not applicable; packaging/tooling change.

## Reward Points Requested
Points requested: **100**
Justification: requested packaging/distribution feature scaffold with cross-platform artifacts and documentation.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented non-obvious logic
- [x] I have updated relevant documentation
- [x] My changes do not introduce new warnings or errors
- [x] I have tested this on at least one supported platform
- [x] I have not committed secrets, API keys, or personal config files
