### PR TITLE
feat: add native packaging workflows

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,79 @@
+name: Build native packages
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - ".github/workflows/package.yml"
+      - "scripts/build_package.py"
+      - "requirements.txt"
+      - "jarvis_launcher.py"
+      - "browserClient.py"
+      - "jarvis_web.html"
+      - "jarvis_visual.html"
+      - "config.example.json"
+
+jobs:
+  package:
+    name: Package ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: windows
+            runner: windows-latest
+          - target: macos
+            runner: macos-latest
+          - target: linux
+            runner: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Linux package dependencies
+        if: matrix.target == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev python3-dev dpkg-dev
+
+      - name: Install macOS package dependencies
+        if: matrix.target == 'macos'
+        run: brew install portaudio pkg-config
+
+      - name: Install Windows package dependencies
+        if: matrix.target == 'windows'
+        shell: pwsh
+        run: choco install nsis -y
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            export PORTAUDIO_PREFIX="$(brew --prefix portaudio)"
+            export PKG_CONFIG_PATH="$PORTAUDIO_PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+            export CFLAGS="-I$PORTAUDIO_PREFIX/include ${CFLAGS:-}"
+            export LDFLAGS="-L$PORTAUDIO_PREFIX/lib ${LDFLAGS:-}"
+          fi
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pyinstaller
+          python -m playwright install chromium
+
+      - name: Build package
+        run: python scripts/build_package.py --platform ${{ matrix.target }}
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: jarvis-${{ matrix.target }}-package
+          path: dist/packages/*
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
   - [Windows](#windows)
   - [macOS](#macos)
   - [Linux](#linux)
+- [📦 Native Packages](#-native-packages)
 - [🎮 Usage](#-usage)
 - [📄 Data Requirements](#-data-requirements)
 - [🔧 Configuration](#-configuration)
@@ -360,6 +361,46 @@ python3 jarvis_launcher.py
 
 ---
 
+## 📦 Native Packages
+
+JARVIS includes packaging automation for release artifacts on all major desktop platforms.
+
+### GitHub Actions
+
+The workflow at `.github/workflows/package.yml` builds packages on pull requests that touch packaging files, on version tags, and from manual dispatch:
+
+| Platform | Artifact |
+|----------|----------|
+| Windows | NSIS `.exe` installer plus `.zip` fallback |
+| macOS | `.dmg` plus `.app.zip` fallback |
+| Linux | Debian `.deb` plus `.tar.gz` fallback |
+
+The workflow installs PortAudio and Python dependencies, bundles `jarvis_launcher.py` with the HTML assets using PyInstaller, then uploads everything under `dist/packages/`.
+
+### Local packaging
+
+```bash
+python -m pip install -r requirements.txt pyinstaller
+python -m playwright install chromium
+python scripts/build_package.py --platform linux
+```
+
+Use `--platform windows`, `--platform macos`, or `--platform linux` on the matching OS. A dry run is available for CI and review:
+
+```bash
+python scripts/build_package.py --platform linux --dry-run
+```
+
+Optional system tools produce richer native artifacts:
+
+| Platform | Optional tool | Result |
+|----------|---------------|--------|
+| Windows | `makensis` | `.exe` installer |
+| macOS | `hdiutil` | `.dmg` image |
+| Linux | `dpkg-deb` | `.deb` package |
+
+---
+
 ## 🎮 Usage
 
 | Action | Result |
@@ -427,6 +468,9 @@ Key settings in the source files:
 toingg-jarvis/
 ├── 🐍 jarvis_launcher.py     # Wake-word listener, app launcher, HTTP server (:8766)
 ├── 🐍 browserClient.py       # Playwright browser automation client
+├── 📦 requirements.txt        # Python dependencies used by launchers and packaging
+├── 📦 scripts/build_package.py # Cross-platform native package builder
+├── 📦 .github/workflows/package.yml # CI matrix for Windows/macOS/Linux artifacts
 ├── 🌐 jarvis_web.html         # Web frontend — WebSocket audio, terminal UI
 ├── 🎨 jarvis_visual.html      # Animated orb / visual display
 ├── 🖥️  JARVIS.bat              # Windows auto-installer & launcher
@@ -523,6 +567,13 @@ There is currently no automated test suite. Contributions adding unit or integra
 python3 browserClient.py --url wss://prepodapi.toingg.com/api/v3/media/browser/default
 # Should print: Browser launched (headless=False, profile=.browser-profile)
 # Then: WebSocket opened
+```
+
+**Verifying packaging automation:**
+
+```bash
+python3 -m py_compile scripts/build_package.py
+python3 scripts/build_package.py --platform linux --dry-run
 ```
 
 ---

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -12,15 +12,26 @@ Requirements:
     pip install sounddevice numpy speechrecognition
 """
 
-import os, sys, time, threading, subprocess, tempfile, json, webbrowser
+import os, sys, time, threading, subprocess, tempfile, json, webbrowser, shutil
 import ctypes, ctypes.wintypes
 import platform as _plat
 
 # ── CONFIG ────────────────────────────────────────────────────────────────────
 _DIR        = os.path.dirname(os.path.abspath(__file__))
-WEB_HTML    = os.path.join(_DIR, "jarvis_web.html")
-VISUAL_HTML = os.path.join(_DIR, "jarvis_visual.html")
-BROWSER_CLIENT = os.path.join(_DIR, "browserClient.py")
+_FROZEN     = bool(getattr(sys, "frozen", False))
+_APP_DIR    = os.path.dirname(sys.executable) if _FROZEN else _DIR
+_RESOURCE_DIR = getattr(sys, "_MEIPASS", _DIR)
+
+def _resource_path(name):
+    for base in (_RESOURCE_DIR, _DIR, _APP_DIR):
+        candidate = os.path.join(base, name)
+        if os.path.exists(candidate):
+            return candidate
+    return os.path.join(_DIR, name)
+
+WEB_HTML    = _resource_path("jarvis_web.html")
+VISUAL_HTML = _resource_path("jarvis_visual.html")
+BROWSER_CLIENT = _resource_path("browserClient.py")
 WAKE_WORDS  = ["hey jarvis", "jarvis", "hey jervis", "hey davis"]
 LAUNCH_COOLDOWN = 4.0
 HTTP_PORT   = 8766
@@ -376,19 +387,40 @@ _visual_proc = None
 _web_proc    = None
 _browser_client_proc = None
 
+def _browser_client_command():
+    exe_name = "browserClient.exe" if _plat.system() == "Windows" else "browserClient"
+    bundled_candidates = [
+        os.path.join(_APP_DIR, "browserClient", exe_name),
+        os.path.join(_APP_DIR, "..", "Resources", "browserClient", exe_name),
+        os.path.join(_RESOURCE_DIR, "browserClient", exe_name),
+    ]
+    for candidate in bundled_candidates:
+        if os.path.exists(candidate):
+            return [candidate]
+
+    if os.path.exists(BROWSER_CLIENT):
+        python_exe = sys.executable
+        if _FROZEN:
+            python_exe = shutil.which("python3") or shutil.which("python") or sys.executable
+        return [python_exe, BROWSER_CLIENT]
+
+    return None
+
 def start_browser_client():
     """Start browserClient.py in the background for browser automation."""
     global _browser_client_proc
     if _browser_client_proc and _browser_client_proc.poll() is None:
         print("  [browser] already running"); return
-    if not os.path.exists(BROWSER_CLIENT):
-        print("  [browser] ⚠  browserClient.py not found"); return
+
+    command = _browser_client_command()
+    if not command:
+        print("  [browser] ⚠  browserClient executable not found"); return
 
     try:
-        _browser_client_proc = subprocess.Popen([sys.executable, BROWSER_CLIENT], cwd=_DIR)
-        print("  [browser] ✅ browserClient.py started")
+        _browser_client_proc = subprocess.Popen(command, cwd=_APP_DIR)
+        print("  [browser] ✅ browserClient started")
     except Exception as e:
-        print(f"  [browser] ⚠  Failed to start browserClient.py: {e}")
+        print(f"  [browser] ⚠  Failed to start browserClient: {e}")
 
 def open_jarvis_visual():
     """Open jarvis_visual.html at the top-center of the screen — the main visible window."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+pyaudio
+numpy
+websocket-client
+rich
+SpeechRecognition
+playwright
+playwright-stealth
+

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Build native distributable artifacts for JARVIS.
+
+The script creates a PyInstaller app first, then wraps it in the native package
+format available on the current runner:
+
+- Windows: NSIS installer when makensis exists, plus a zip fallback.
+- macOS: .dmg when hdiutil exists, plus a zip fallback.
+- Linux: .deb when dpkg-deb exists, plus a tar.gz fallback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+import textwrap
+import zipfile
+from pathlib import Path
+
+
+APP_NAME = "JARVIS"
+PACKAGE_NAME = "jarvis"
+VERSION = os.environ.get("JARVIS_PACKAGE_VERSION", "0.1.0")
+ROOT = Path(__file__).resolve().parents[1]
+DIST_DIR = ROOT / "dist"
+BUILD_DIR = ROOT / "build" / "native"
+PACKAGE_DIR = DIST_DIR / "packages"
+
+LAUNCHER_RESOURCE_FILES = [
+    "jarvis_web.html",
+    "jarvis_visual.html",
+    "config.example.json",
+]
+
+
+def run(command: list[str], *, dry_run: bool = False) -> None:
+    print("+", " ".join(command))
+    if not dry_run:
+        subprocess.run(command, cwd=ROOT, check=True)
+
+
+def clean() -> None:
+    for path in [DIST_DIR, ROOT / "build", ROOT / f"{APP_NAME}.spec", ROOT / "browserClient.spec"]:
+        if path.is_file():
+            path.unlink()
+        elif path.is_dir():
+            shutil.rmtree(path)
+    PACKAGE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def pyinstaller_command(
+    target_platform: str,
+    entrypoint: str,
+    name: str,
+    *,
+    resources: list[str] | None = None,
+    windowed: bool = False,
+) -> list[str]:
+    data_separator = ";" if target_platform == "windows" else ":"
+    command = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--noconfirm",
+        "--clean",
+        "--onedir",
+        "--name",
+        name,
+    ]
+
+    if windowed:
+        command.append("--windowed")
+
+    for resource in resources or []:
+        command.extend(["--add-data", f"{resource}{data_separator}."])
+
+    command.append(entrypoint)
+    return command
+
+
+def build_pyinstaller_app(target_platform: str, *, dry_run: bool = False) -> None:
+    run(
+        pyinstaller_command(target_platform, "browserClient.py", "browserClient"),
+        dry_run=dry_run,
+    )
+    run(
+        pyinstaller_command(
+            target_platform,
+            "jarvis_launcher.py",
+            APP_NAME,
+            resources=LAUNCHER_RESOURCE_FILES + ["browserClient.py"],
+            windowed=target_platform == "macos",
+        ),
+        dry_run=dry_run,
+    )
+
+    if dry_run:
+        return
+
+    browser_dist = DIST_DIR / "browserClient"
+    if target_platform == "macos":
+        browser_destination = DIST_DIR / f"{APP_NAME}.app" / "Contents" / "Resources" / "browserClient"
+    else:
+        browser_destination = DIST_DIR / APP_NAME / "browserClient"
+
+    if browser_dist.exists():
+        copy_tree(browser_dist, browser_destination)
+
+
+def copy_tree(source: Path, destination: Path) -> None:
+    if destination.exists():
+        shutil.rmtree(destination)
+    shutil.copytree(source, destination)
+
+
+def zip_path(source: Path, destination: Path) -> None:
+    if destination.exists():
+        destination.unlink()
+    if source.is_dir():
+        with zipfile.ZipFile(destination, "w", zipfile.ZIP_DEFLATED) as archive:
+            for path in source.rglob("*"):
+                archive.write(path, path.relative_to(source.parent))
+    else:
+        with zipfile.ZipFile(destination, "w", zipfile.ZIP_DEFLATED) as archive:
+            archive.write(source, source.name)
+
+
+def package_windows(*, dry_run: bool = False) -> None:
+    app_dir = DIST_DIR / APP_NAME
+    installer_script = BUILD_DIR / "jarvis-installer.nsi"
+    installer = PACKAGE_DIR / f"{APP_NAME}-{VERSION}-windows-installer.exe"
+    zip_artifact = PACKAGE_DIR / f"{APP_NAME}-{VERSION}-windows.zip"
+
+    if dry_run:
+        print(f"Would package Windows app from {app_dir}")
+        return
+
+    BUILD_DIR.mkdir(parents=True, exist_ok=True)
+    installer_script.write_text(
+        textwrap.dedent(
+            f"""
+            Unicode True
+            Name "{APP_NAME}"
+            OutFile "{installer}"
+            InstallDir "$PROGRAMFILES\\{APP_NAME}"
+            RequestExecutionLevel admin
+
+            Page directory
+            Page instfiles
+
+            Section "Install"
+              SetOutPath "$INSTDIR"
+              File /r "{app_dir}\\*"
+              CreateShortcut "$DESKTOP\\{APP_NAME}.lnk" "$INSTDIR\\{APP_NAME}.exe"
+              CreateShortcut "$SMPROGRAMS\\{APP_NAME}.lnk" "$INSTDIR\\{APP_NAME}.exe"
+            SectionEnd
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    makensis = shutil.which("makensis")
+    if makensis:
+        run([makensis, str(installer_script)])
+    else:
+        print("makensis not found; skipping .exe installer and creating zip fallback")
+
+    zip_path(app_dir, zip_artifact)
+    print(f"Created {zip_artifact}")
+
+
+def package_macos(*, dry_run: bool = False) -> None:
+    app_bundle = DIST_DIR / f"{APP_NAME}.app"
+    zip_artifact = PACKAGE_DIR / f"{APP_NAME}-{VERSION}-macos-app.zip"
+    dmg_artifact = PACKAGE_DIR / f"{APP_NAME}-{VERSION}-macos.dmg"
+
+    if dry_run:
+        print(f"Would package macOS app from {app_bundle}")
+        return
+
+    if app_bundle.exists() and shutil.which("hdiutil"):
+        run(
+            [
+                "hdiutil",
+                "create",
+                "-volname",
+                APP_NAME,
+                "-srcfolder",
+                str(app_bundle),
+                "-ov",
+                "-format",
+                "UDZO",
+                str(dmg_artifact),
+            ]
+        )
+    else:
+        print("hdiutil or .app bundle not found; skipping .dmg artifact")
+
+    if app_bundle.exists():
+        zip_path(app_bundle, zip_artifact)
+        print(f"Created {zip_artifact}")
+    else:
+        zip_path(DIST_DIR / APP_NAME, zip_artifact)
+        print(f"Created {zip_artifact}")
+
+
+def write_file(path: Path, contents: str, mode: int | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents, encoding="utf-8")
+    if mode is not None:
+        path.chmod(mode)
+
+
+def package_linux(*, dry_run: bool = False) -> None:
+    app_dir = DIST_DIR / APP_NAME
+    package_root = BUILD_DIR / f"{PACKAGE_NAME}_{VERSION}_amd64"
+    opt_dir = package_root / "opt" / PACKAGE_NAME
+    bin_launcher = package_root / "usr" / "bin" / PACKAGE_NAME
+    desktop_file = package_root / "usr" / "share" / "applications" / "jarvis.desktop"
+    control_file = package_root / "DEBIAN" / "control"
+    deb_artifact = PACKAGE_DIR / f"{PACKAGE_NAME}_{VERSION}_amd64.deb"
+    tar_artifact = PACKAGE_DIR / f"{APP_NAME}-{VERSION}-linux.tar.gz"
+
+    if dry_run:
+        print(f"Would package Linux app from {app_dir}")
+        return
+
+    if package_root.exists():
+        shutil.rmtree(package_root)
+    copy_tree(app_dir, opt_dir / APP_NAME)
+
+    write_file(
+        bin_launcher,
+        textwrap.dedent(
+            f"""
+            #!/bin/sh
+            exec /opt/{PACKAGE_NAME}/{APP_NAME}/{APP_NAME} "$@"
+            """
+        ).lstrip(),
+        mode=0o755,
+    )
+    write_file(
+        desktop_file,
+        textwrap.dedent(
+            f"""
+            [Desktop Entry]
+            Type=Application
+            Name=JARVIS
+            Comment=AI voice terminal powered by Toingg
+            Exec=/usr/bin/{PACKAGE_NAME}
+            Terminal=true
+            Categories=Utility;AudioVideo;
+            """
+        ).lstrip(),
+    )
+    write_file(
+        control_file,
+        textwrap.dedent(
+            f"""
+            Package: {PACKAGE_NAME}
+            Version: {VERSION}
+            Section: utils
+            Priority: optional
+            Architecture: amd64
+            Maintainer: PG-AGI
+            Description: JARVIS AI voice terminal powered by Toingg
+             Native package generated from the toingg-jarvis project.
+            """
+        ).lstrip(),
+    )
+
+    dpkg_deb = shutil.which("dpkg-deb")
+    if dpkg_deb:
+        run([dpkg_deb, "--build", str(package_root), str(deb_artifact)])
+    else:
+        print("dpkg-deb not found; skipping .deb artifact")
+
+    with tarfile.open(tar_artifact, "w:gz") as archive:
+        archive.add(app_dir, arcname=APP_NAME)
+    print(f"Created {tar_artifact}")
+
+
+def detect_platform() -> str:
+    system = platform.system()
+    if system == "Windows":
+        return "windows"
+    if system == "Darwin":
+        return "macos"
+    return "linux"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build native JARVIS packages")
+    parser.add_argument(
+        "--platform",
+        choices=["windows", "macos", "linux"],
+        default=detect_platform(),
+        help="Target packaging platform. Defaults to the current OS.",
+    )
+    parser.add_argument(
+        "--skip-clean",
+        action="store_true",
+        help="Keep existing build/dist directories before packaging.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print build steps without invoking PyInstaller or package tools.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.skip_clean and not args.dry_run:
+        clean()
+    else:
+        PACKAGE_DIR.mkdir(parents=True, exist_ok=True)
+
+    build_pyinstaller_app(args.platform, dry_run=args.dry_run)
+
+    if args.platform == "windows":
+        package_windows(dry_run=args.dry_run)
+    elif args.platform == "macos":
+        package_macos(dry_run=args.dry_run)
+    else:
+        package_linux(dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
/claim #13

## Summary
- Added shared Python dependency metadata in `requirements.txt`.
- Added `scripts/build_package.py` to build PyInstaller app bundles and wrap them as Windows, macOS, and Linux release artifacts.
- Added a GitHub Actions packaging matrix for Windows, macOS, and Linux with native artifact upload.
- Updated launcher resource lookup so bundled/native layouts can resolve HTML assets and the packaged `browserClient` executable.
- Documented CI and local packaging commands in `README.md`.

## Validation
- `python3 -m py_compile scripts/build_package.py jarvis_launcher.py browserClient.py`
- `python3 scripts/build_package.py --platform linux --dry-run`
- Source-mode browser client resolution check passed.
- Full local macOS packaging run completed in a temporary venv after installing PortAudio/pkg-config and PyInstaller, producing:
  - `dist/packages/JARVIS-0.1.0-macos.dmg`
  - `dist/packages/JARVIS-0.1.0-macos-app.zip`
- Confirmed bundled helper exists at `JARVIS.app/Contents/Resources/browserClient/browserClient`.

## Demo / artifact note
This is release packaging infrastructure rather than an interactive UI change. The local package build produced the native macOS artifacts above; CI will produce the full cross-platform artifact set on the packaging workflow.