### PR TITLE
feat: add optional Pipecat Gemini backend

### DIFF
--- a/JARVIS_README.md
+++ b/JARVIS_README.md
@@ -92,6 +92,7 @@ CAMP_ID = "your-campaign-id-here"
 ## What it does
 
 - Connects to your JARVIS AI campaign over WebSocket
+- Can optionally route audio through a local Pipecat + Gemini Live backend
 - Opens a live terminal UI with spectrum visualizer
 - Press **Enter** to speak — JARVIS listens and responds via audio
 - When JARVIS fetches news/weather/war updates, browser tabs open automatically in a 2×2 grid
@@ -118,3 +119,15 @@ pip install pyaudio
 
 **Audio distortion / no sound:**
 - Check your default output device is set correctly in system sound settings
+
+
+## Optional Pipecat + Gemini backend
+
+Install optional dependencies with:
+
+```bash
+python3 -m pip install -r requirements-pipecat-gemini.txt
+export GOOGLE_API_KEY=your_google_ai_studio_key
+```
+
+Set `BACKEND` to `pipecat_gemini` in `config.json`. The launcher starts `pipecat_gemini_proxy.py` locally and the browser connects to `ws://localhost:8767/ws`. Leave `BACKEND` as `toingg` to keep the original Toingg pipeline.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ All three layers run simultaneously and communicate over `localhost:8766`.
 **🎙️ Voice Interaction**
 - Wake-word activation — just say **"Hey Jarvis"**
 - Real-time WebSocket streaming to Toingg AI
+- Optional Pipecat + Gemini Live backend for local experimentation
 - Barge-in support while AI is speaking
 - SpeechRecognition + Web Speech API
 
@@ -400,6 +401,17 @@ cp config.example.json config.json
 
 > 🆓 The default campaign ID `69d79c72b7ab98a9ef49bcad` is the **free JARVIS demo** shown in the preview video — no setup required beyond your API token.
 
+### Optional Pipecat + Gemini backend
+
+To try Gemini Live through Pipecat without exposing a Google API key in the browser:
+
+```bash
+python3 -m pip install -r requirements-pipecat-gemini.txt
+export GOOGLE_API_KEY=your_google_ai_studio_key
+```
+
+Then set `BACKEND` to `pipecat_gemini` in `config.json` and run `python3 jarvis_launcher.py`. The launcher starts `pipecat_gemini_proxy.py` on `ws://localhost:8767/ws`, while the web UI keeps using the existing Float32 audio protocol. If `BACKEND` remains `toingg`, nothing changes.
+
 > 🔒 `config.json` is listed in `.gitignore` and will never be committed to version control.
 
 ---
@@ -413,6 +425,8 @@ Key settings in the source files:
 | `WAKE_WORDS` | `jarvis_launcher.py` | `["hey jarvis", "jarvis", ...]` | Phrases that trigger full launch |
 | `LAUNCH_COOLDOWN` | `jarvis_launcher.py` | `4.0` s | Minimum seconds between consecutive launches |
 | `HTTP_PORT` | `jarvis_launcher.py` | `8766` | Local server port |
+| `BACKEND` | `config.json` | `toingg` | Use `toingg` or optional `pipecat_gemini` backend |
+| `PIPECAT_WS_URL` | `config.json` | `ws://localhost:8767/ws` | Local Pipecat/Gemini WebSocket endpoint |
 | `energy_threshold` | `jarvis_launcher.py` | `400` | Mic sensitivity (lower = more sensitive) |
 | `pause_threshold` | `jarvis_launcher.py` | `1.2` s | Silence duration before phrase ends |
 | `BROWSER_ACTION_DELAY_MS` | `jarvis_web.html` | `900` ms | Delay before first browser tab opens after audio starts |

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,14 @@
 {
+  "BACKEND": "toingg",
   "WS_URL": "wss://prepodapi.toingg.com/api/v3/media/streaming",
-  "TOKEN":  "your-token-here",
-  "CAMP_ID": "your-campaign-id-here"
+  "TOKEN": "your-token-here",
+  "CAMP_ID": "your-campaign-id-here",
+
+  "PIPECAT_WS_URL": "ws://localhost:8767/ws",
+  "PIPECAT_HOST": "localhost",
+  "PIPECAT_PORT": 8767,
+  "PIPECAT_WS_PATH": "/ws",
+  "PIPECAT_GEMINI_API_KEY_ENV": "GOOGLE_API_KEY",
+  "PIPECAT_GEMINI_MODEL": "models/gemini-2.5-flash-native-audio-preview-12-2025",
+  "PIPECAT_GEMINI_VOICE": "Puck"
 }

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -21,6 +21,7 @@ _DIR        = os.path.dirname(os.path.abspath(__file__))
 WEB_HTML    = os.path.join(_DIR, "jarvis_web.html")
 VISUAL_HTML = os.path.join(_DIR, "jarvis_visual.html")
 BROWSER_CLIENT = os.path.join(_DIR, "browserClient.py")
+PIPECAT_GEMINI_PROXY = os.path.join(_DIR, "pipecat_gemini_proxy.py")
 WAKE_WORDS  = ["hey jarvis", "jarvis", "hey jervis", "hey davis"]
 LAUNCH_COOLDOWN = 4.0
 HTTP_PORT   = 8766
@@ -375,6 +376,32 @@ def close_all_url_windows(auto=False):
 _visual_proc = None
 _web_proc    = None
 _browser_client_proc = None
+_pipecat_gemini_proc = None
+
+
+def _load_launcher_config():
+    try:
+        with open(os.path.join(_DIR, "config.json"), "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+def start_pipecat_gemini_backend():
+    """Start the optional local Pipecat + Gemini backend when configured."""
+    global _pipecat_gemini_proc
+    cfg = _load_launcher_config()
+    backend = str(cfg.get("BACKEND", "toingg")).strip().lower()
+    if backend != "pipecat_gemini":
+        return
+    if _pipecat_gemini_proc and _pipecat_gemini_proc.poll() is None:
+        print("  [pipecat] already running"); return
+    if not os.path.exists(PIPECAT_GEMINI_PROXY):
+        print("  [pipecat] ⚠  pipecat_gemini_proxy.py not found"); return
+    try:
+        _pipecat_gemini_proc = subprocess.Popen([sys.executable, PIPECAT_GEMINI_PROXY], cwd=_DIR)
+        print("  [pipecat] ✅ Gemini backend started")
+    except Exception as e:
+        print(f"  [pipecat] ⚠  Failed to start Gemini backend: {e}")
 
 def start_browser_client():
     """Start browserClient.py in the background for browser automation."""
@@ -915,7 +942,13 @@ def _open_url(url):
         webbrowser.open(url)
 
 def check_api_key():
-    """If token is missing or placeholder, run interactive setup in the terminal."""
+    """If Toingg token is missing, run setup unless Pipecat backend is selected."""
+    cfg = _load_launcher_config()
+    if str(cfg.get("BACKEND", "toingg")).strip().lower() == "pipecat_gemini":
+        api_env = str(cfg.get("PIPECAT_GEMINI_API_KEY_ENV") or "GOOGLE_API_KEY")
+        if not os.getenv(api_env):
+            print(f"  [pipecat] ⚠  {api_env} is not set; Gemini backend will wait for configuration")
+        return
     token = _load_token()
     if _is_valid_token(token):
         return  # token looks valid, continue normally
@@ -999,6 +1032,7 @@ def main():
     print(f"  🌐  Server   : http://localhost:{HTTP_PORT}/\n")
 
     start_http_server()
+    start_pipecat_gemini_backend()
 
     threads = [
         threading.Thread(target=voice_listener, daemon=True, name="voice"),

--- a/jarvis_web.html
+++ b/jarvis_web.html
@@ -437,6 +437,8 @@ html, body {
 let WS_URL  = "";
 let TOKEN   = "";
 let CAMP_ID = "";
+let BACKEND = "toingg";
+let PIPECAT_WS_URL = "";
 const SAMPLE_IN  = 8000;    // mic rate sent to server
 const SAMPLE_OUT = 22050;   // server audio rate
 const CHUNK_SEND = 2048;    // float32 samples per WS send (matches py: 4×512)
@@ -817,7 +819,7 @@ function ensureAudioCtx() {
 // ═══════════════════════════════════════════════════════════════════
 //  AUDIO PLAYBACK  (mirrors playback_worker + enqueue_audio)
 // ═══════════════════════════════════════════════════════════════════
-function enqueueAudio(b64) {
+function enqueueAudio(b64, sampleRate = SAMPLE_OUT) {
   if (dropAudio) return;
   ensureAudioCtx();
   if (playbackIdleTimer) {
@@ -828,7 +830,7 @@ function enqueueAudio(b64) {
   const samples = b64ToFloat32(b64);
   if (!samples.length) return;
 
-  const buf    = audioCtx.createBuffer(1, samples.length, SAMPLE_OUT);
+  const buf    = audioCtx.createBuffer(1, samples.length, sampleRate);
   buf.copyToChannel(samples, 0);
 
   const src    = audioCtx.createBufferSource();
@@ -841,7 +843,7 @@ function enqueueAudio(b64) {
     ? nextPlayTime
     : underrunAt;
   src.start(startAt);
-  nextPlayTime = startAt + samples.length / SAMPLE_OUT;
+  nextPlayTime = startAt + samples.length / sampleRate;
 
   playScheduled++;
   activeAudioSources.add(src);
@@ -1419,17 +1421,23 @@ function connectWs() {
     setStatus("SYSTEMS ONLINE — AUTO-STARTING MIC...");
     logChat("sys", "◈ SECURE CHANNEL ESTABLISHED");
 
-    wsConn.send(JSON.stringify({
+    const startPayload = {
       event:        "start",
-      token:        TOKEN,
-      campId:       CAMP_ID,
+      backend:      BACKEND,
       codec:        "f32_raw",
       sampleRate:   SAMPLE_IN,
-      asr:          "AZURE",
       startMessage: true,
-      clearMemory: true,
-      wordsToInterrupt: 2
-    }));
+    };
+    if (BACKEND !== "pipecat_gemini") {
+      Object.assign(startPayload, {
+        token:        TOKEN,
+        campId:       CAMP_ID,
+        asr:          "AZURE",
+        clearMemory: true,
+        wordsToInterrupt: 2,
+      });
+    }
+    wsConn.send(JSON.stringify(startPayload));
 
     // auto-start mic after 1.2s — same as terminal
     setTimeout(startMic, 1200);
@@ -1448,7 +1456,7 @@ function connectWs() {
 
     if (ev === "media") {
       const p = msg.media?.payload;
-      if (p) enqueueAudio(p);
+      if (p) enqueueAudio(p, msg.media?.sampleRate || SAMPLE_OUT);
 
     } else if (ev === "aiTextStream") {
       const chunk = msg.text_chunk || "";
@@ -1611,7 +1619,9 @@ async function loadConfig() {
   const res = await fetch("config.json");
   if (!res.ok) throw new Error(`config.json not found (${res.status})`);
   const cfg = await res.json();
-  WS_URL  = cfg.WS_URL  || "";
+  BACKEND = String(cfg.BACKEND || "toingg").trim().toLowerCase();
+  PIPECAT_WS_URL = cfg.PIPECAT_WS_URL || `ws://${cfg.PIPECAT_HOST || "localhost"}:${cfg.PIPECAT_PORT || 8767}${cfg.PIPECAT_WS_PATH || "/ws"}`;
+  WS_URL  = BACKEND === "pipecat_gemini" ? PIPECAT_WS_URL : (cfg.WS_URL || "");
   TOKEN   = cfg.TOKEN   || "";
   CAMP_ID = cfg.CAMP_ID || "";
 }
@@ -1626,7 +1636,7 @@ async function boot() {
     return;
   }
 
-  if (!TOKEN) {
+  if (BACKEND !== "pipecat_gemini" && !TOKEN) {
     showSetup();
     return;
   }

--- a/pipecat_gemini_proxy.py
+++ b/pipecat_gemini_proxy.py
@@ -1,0 +1,302 @@
+"""Optional Pipecat + Gemini Live backend for J.A.R.V.I.S.
+
+This module is intentionally optional: the default Toingg backend still works
+without Pipecat installed. When `BACKEND=pipecat_gemini` is configured,
+`jarvis_launcher.py` starts this local WebSocket proxy and `jarvis_web.html`
+connects to it instead of the Toingg streaming endpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 8767
+DEFAULT_WS_PATH = "/ws"
+DEFAULT_MODEL = "models/gemini-2.5-flash-native-audio-preview-12-2025"
+DEFAULT_VOICE = "Puck"
+DEFAULT_SYSTEM_INSTRUCTION = (
+    "You are JARVIS, a concise, friendly desktop voice assistant. "
+    "Answer briefly because your response is spoken aloud."
+)
+
+
+@dataclass(frozen=True)
+class PipecatGeminiConfig:
+    host: str = DEFAULT_HOST
+    port: int = DEFAULT_PORT
+    ws_path: str = DEFAULT_WS_PATH
+    api_key_env: str = "GOOGLE_API_KEY"
+    model: str = DEFAULT_MODEL
+    voice: str = DEFAULT_VOICE
+    system_instruction: str = DEFAULT_SYSTEM_INSTRUCTION
+    input_sample_rate: int = 8000
+    output_sample_rate: int = 24000
+
+    @property
+    def ws_url(self) -> str:
+        path = self.ws_path if self.ws_path.startswith("/") else f"/{self.ws_path}"
+        return f"ws://{self.host}:{self.port}{path}"
+
+
+def _truthy(value: Any) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def selected_backend(config: dict[str, Any]) -> str:
+    return str(config.get("BACKEND") or config.get("backend") or "toingg").strip().lower()
+
+
+def load_project_config(config_path: str | os.PathLike[str] | None = None) -> dict[str, Any]:
+    path = Path(config_path or Path(__file__).with_name("config.json"))
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_pipecat_config(config_path: str | os.PathLike[str] | None = None) -> PipecatGeminiConfig:
+    cfg = load_project_config(config_path)
+    return PipecatGeminiConfig(
+        host=str(cfg.get("PIPECAT_HOST") or DEFAULT_HOST),
+        port=int(cfg.get("PIPECAT_PORT") or DEFAULT_PORT),
+        ws_path=str(cfg.get("PIPECAT_WS_PATH") or DEFAULT_WS_PATH),
+        api_key_env=str(cfg.get("PIPECAT_GEMINI_API_KEY_ENV") or "GOOGLE_API_KEY"),
+        model=str(cfg.get("PIPECAT_GEMINI_MODEL") or DEFAULT_MODEL),
+        voice=str(cfg.get("PIPECAT_GEMINI_VOICE") or DEFAULT_VOICE),
+        system_instruction=str(
+            cfg.get("PIPECAT_GEMINI_SYSTEM_INSTRUCTION") or DEFAULT_SYSTEM_INSTRUCTION
+        ),
+        input_sample_rate=int(cfg.get("PIPECAT_INPUT_SAMPLE_RATE") or 8000),
+        output_sample_rate=int(cfg.get("PIPECAT_OUTPUT_SAMPLE_RATE") or 24000),
+    )
+
+
+def pipecat_enabled(config_path: str | os.PathLike[str] | None = None) -> bool:
+    return selected_backend(load_project_config(config_path)) == "pipecat_gemini"
+
+
+def effective_websocket_url(config: dict[str, Any]) -> str:
+    """Return the browser WebSocket URL for the selected backend."""
+    if selected_backend(config) == "pipecat_gemini":
+        if config.get("PIPECAT_WS_URL"):
+            return str(config["PIPECAT_WS_URL"])
+        return PipecatGeminiConfig(
+            host=str(config.get("PIPECAT_HOST") or DEFAULT_HOST),
+            port=int(config.get("PIPECAT_PORT") or DEFAULT_PORT),
+            ws_path=str(config.get("PIPECAT_WS_PATH") or DEFAULT_WS_PATH),
+        ).ws_url
+    return str(config.get("WS_URL") or "")
+
+
+def float32_b64_to_pcm16(payload: str) -> bytes:
+    """Convert the current web UI Float32Array base64 payload to PCM16 mono."""
+    raw = base64.b64decode(payload)
+    if len(raw) % 4:
+        raise ValueError("Float32 audio payload length must be divisible by 4")
+    samples = struct.iter_unpack("<f", raw)
+    out = bytearray()
+    for (sample,) in samples:
+        clipped = max(-1.0, min(1.0, float(sample)))
+        out.extend(struct.pack("<h", int(clipped * 32767)))
+    return bytes(out)
+
+
+def pcm16_to_float32_b64(audio: bytes) -> str:
+    """Convert PCM16 mono bytes from Pipecat/Gemini into the web UI format."""
+    if len(audio) % 2:
+        raise ValueError("PCM16 audio length must be divisible by 2")
+    out = bytearray()
+    for (sample,) in struct.iter_unpack("<h", audio):
+        out.extend(struct.pack("<f", max(-1.0, min(1.0, sample / 32768.0))))
+    return base64.b64encode(bytes(out)).decode("ascii")
+
+
+def make_jarvis_json_serializer(config: PipecatGeminiConfig):
+    """Create a Pipecat FrameSerializer for the existing JARVIS web protocol."""
+    from pipecat.frames.frames import (  # type: ignore[import-not-found]
+        InputAudioRawFrame,
+        OutputAudioRawFrame,
+        TextFrame,
+        TranscriptionFrame,
+    )
+    from pipecat.serializers.base_serializer import (  # type: ignore[import-not-found]
+        FrameSerializer,
+        FrameSerializerType,
+    )
+
+    class JarvisJsonFrameSerializer(FrameSerializer):
+        @property
+        def type(self):
+            return FrameSerializerType.TEXT
+
+        async def deserialize(self, data: str | bytes):
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
+            msg = json.loads(data)
+            event = msg.get("event")
+            if event == "media":
+                payload = (msg.get("media") or {}).get("payload")
+                if not payload:
+                    return None
+                pcm16 = float32_b64_to_pcm16(payload)
+                return InputAudioRawFrame(
+                    audio=pcm16,
+                    sample_rate=config.input_sample_rate,
+                    num_channels=1,
+                )
+            return None
+
+        async def serialize(self, frame):
+            if isinstance(frame, OutputAudioRawFrame):
+                payload = pcm16_to_float32_b64(frame.audio)
+                return json.dumps({"event": "media", "media": {"payload": payload, "sampleRate": frame.sample_rate}})
+            if isinstance(frame, TranscriptionFrame):
+                return json.dumps(
+                    {"event": "transcription", "role": "user", "content": frame.text}
+                )
+            if isinstance(frame, TextFrame):
+                return json.dumps({"event": "aiTextStream", "text_chunk": frame.text})
+            return None
+
+    return JarvisJsonFrameSerializer()
+
+
+async def run_bot(websocket, config: PipecatGeminiConfig) -> None:
+    """Run one Pipecat Gemini Live pipeline for a connected browser client."""
+    from loguru import logger  # type: ignore[import-not-found]
+    from pipecat.audio.vad.silero import SileroVADAnalyzer  # type: ignore[import-not-found]
+    from pipecat.frames.frames import LLMRunFrame  # type: ignore[import-not-found]
+    from pipecat.pipeline.pipeline import Pipeline  # type: ignore[import-not-found]
+    from pipecat.pipeline.runner import PipelineRunner  # type: ignore[import-not-found]
+    from pipecat.pipeline.task import PipelineParams, PipelineTask  # type: ignore[import-not-found]
+    from pipecat.processors.aggregators.llm_context import LLMContext  # type: ignore[import-not-found]
+    from pipecat.processors.aggregators.llm_response_universal import (  # type: ignore[import-not-found]
+        LLMContextAggregatorPair,
+        LLMUserAggregatorParams,
+    )
+    from pipecat.services.google.gemini_live.llm import (  # type: ignore[import-not-found]
+        GeminiLiveLLMService,
+    )
+    from pipecat.transports.websocket.fastapi import (  # type: ignore[import-not-found]
+        FastAPIWebsocketParams,
+        FastAPIWebsocketTransport,
+    )
+
+    api_key = os.getenv(config.api_key_env)
+    if not api_key:
+        await websocket.send_json(
+            {
+                "event": "transcription",
+                "role": "ai",
+                "content": f"Missing {config.api_key_env}; Pipecat Gemini backend is not configured.",
+            }
+        )
+        await websocket.close()
+        return
+
+    transport = FastAPIWebsocketTransport(
+        websocket=websocket,
+        params=FastAPIWebsocketParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+            add_wav_header=False,
+            serializer=make_jarvis_json_serializer(config),
+        ),
+    )
+    llm = GeminiLiveLLMService(
+        api_key=api_key,
+        settings=GeminiLiveLLMService.Settings(
+            model=config.model,
+            voice=config.voice,
+            system_instruction=config.system_instruction,
+        ),
+    )
+    context = LLMContext(
+        [
+            {
+                "role": "user",
+                "content": "Start by greeting the user briefly as JARVIS.",
+            }
+        ]
+    )
+    user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+        context,
+        user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer()),
+    )
+    pipeline = Pipeline(
+        [transport.input(), user_aggregator, llm, transport.output(), assistant_aggregator]
+    )
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
+    )
+
+    @task.rtvi.event_handler("on_client_ready")
+    async def on_client_ready(rtvi):
+        logger.info("JARVIS Pipecat client ready")
+        await task.queue_frames([LLMRunFrame()])
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        logger.info("JARVIS web client connected to Pipecat Gemini")
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info("JARVIS web client disconnected from Pipecat Gemini")
+        await task.cancel()
+
+    runner = PipelineRunner(handle_sigint=False)
+    await runner.run(task)
+
+
+def create_app(config: PipecatGeminiConfig | None = None):
+    from fastapi import FastAPI, WebSocket  # type: ignore[import-not-found]
+
+    config = config or load_pipecat_config()
+    app = FastAPI(title="JARVIS Pipecat Gemini Backend")
+
+    @app.get("/health")
+    async def health():
+        return {
+            "ok": True,
+            "backend": "pipecat_gemini",
+            "model": config.model,
+            "voice": config.voice,
+            "ws": config.ws_url,
+        }
+
+    @app.websocket(config.ws_path)
+    async def websocket_endpoint(websocket: WebSocket):
+        await websocket.accept()
+        await run_bot(websocket, config)
+
+    return app
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run the optional JARVIS Pipecat Gemini backend")
+    parser.add_argument("--config", default=None, help="Path to config.json")
+    args = parser.parse_args(argv)
+    config = load_pipecat_config(args.config)
+
+    try:
+        import uvicorn  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise SystemExit(
+            "Missing optional dependencies. Install with: "
+            "pip install -r requirements-pipecat-gemini.txt"
+        ) from exc
+
+    uvicorn.run(create_app(config), host=config.host, port=config.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-pipecat-gemini.txt
+++ b/requirements-pipecat-gemini.txt
@@ -1,0 +1,6 @@
+# Optional backend for BACKEND=pipecat_gemini
+fastapi>=0.115
+uvicorn[standard]>=0.30
+loguru>=0.7
+python-dotenv>=1.0
+pipecat-ai[google,websocket]>=0.0.105

--- a/test_pipecat_gemini_proxy.py
+++ b/test_pipecat_gemini_proxy.py
@@ -1,0 +1,55 @@
+import base64
+import json
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+from pipecat_gemini_proxy import (
+    DEFAULT_WS_PATH,
+    PipecatGeminiConfig,
+    effective_websocket_url,
+    float32_b64_to_pcm16,
+    load_pipecat_config,
+    pcm16_to_float32_b64,
+    pipecat_enabled,
+    selected_backend,
+)
+
+
+class PipecatGeminiProxyTests(unittest.TestCase):
+    def test_default_backend_is_toingg(self):
+        self.assertEqual(selected_backend({}), "toingg")
+        self.assertEqual(effective_websocket_url({"WS_URL": "wss://example"}), "wss://example")
+
+    def test_pipecat_url_defaults(self):
+        cfg = {"BACKEND": "pipecat_gemini"}
+        self.assertEqual(effective_websocket_url(cfg), f"ws://localhost:8767{DEFAULT_WS_PATH}")
+
+    def test_load_pipecat_config_from_config_json(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "config.json"
+            path.write_text(json.dumps({"BACKEND": "pipecat_gemini", "PIPECAT_PORT": 9001}))
+            self.assertTrue(pipecat_enabled(path))
+            self.assertEqual(load_pipecat_config(path).port, 9001)
+
+    def test_float32_to_pcm16_clips(self):
+        raw = struct.pack("<fff", -2.0, 0.0, 2.0)
+        payload = base64.b64encode(raw).decode("ascii")
+        pcm = float32_b64_to_pcm16(payload)
+        self.assertEqual(struct.unpack("<hhh", pcm), (-32767, 0, 32767))
+
+    def test_pcm16_to_float32_round_trip_shape(self):
+        payload = pcm16_to_float32_b64(struct.pack("<hh", -32768, 32767))
+        raw = base64.b64decode(payload)
+        self.assertEqual(len(raw), 8)
+        left, right = struct.unpack("<ff", raw)
+        self.assertLessEqual(left, -0.99)
+        self.assertGreaterEqual(right, 0.99)
+
+    def test_config_ws_url_property(self):
+        self.assertEqual(PipecatGeminiConfig(host="127.0.0.1", port=9999).ws_url, "ws://127.0.0.1:9999/ws")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #11

## Linked Issue
Closes #11

## Summary of Changes
- Added `pipecat_gemini_proxy.py`, an optional local Pipecat + Gemini Live WebSocket backend that preserves the existing JARVIS Float32 browser audio protocol.
- Added config-driven backend selection: `BACKEND=toingg` keeps the original pipeline; `BACKEND=pipecat_gemini` routes the web UI to `ws://localhost:8767/ws` and starts the local proxy from `jarvis_launcher.py`.
- Implemented a custom Pipecat `FrameSerializer` adapter for current JARVIS JSON media events, converting browser Float32 audio to PCM16 input frames and Pipecat/Gemini PCM16 output frames back to browser Float32 audio.
- Added optional dependency file `requirements-pipecat-gemini.txt` plus README/JARVIS_README setup docs.
- Added regression tests for backend selection, config loading, and audio format conversion.

References used while implementing:
- Pipecat Gemini Live docs: https://docs.pipecat.ai/api-reference/server/services/s2s/gemini-live
- Pipecat FastAPI WebSocket transport docs: https://docs.pipecat.ai/api-reference/server/services/transport/fastapi-websocket
- Pipecat example pattern: https://github.com/pipecat-ai/pipecat-examples/blob/main/websocket/server/bot_fast_api.py

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / tooling / config change

## Testing Performed
- [ ] Tested on **Windows**
- [x] Tested on **macOS**
- [ ] Tested on **Linux**
- Platform tested on: macOS (local)
- Python version: Python 3.13

Steps to verify:
1. `python3 -m unittest test_pipecat_gemini_proxy.py`
2. `python3 -m py_compile jarvis_launcher.py browserClient.py pipecat_gemini_proxy.py`
3. `python3 - <<'PY' ... json.loads(config.example.json) ... PY`
4. `git diff --check`

## Screenshots / Recordings
Not applicable; backend/config integration.

## Reward Points Requested
Points requested: **100**
Justification: requested optional backend feature with tests and docs; Toingg remains the default path.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented non-obvious logic
- [x] I have updated relevant documentation
- [x] My changes do not introduce new warnings or errors
- [x] I have tested this on at least one supported platform
- [x] I have not committed secrets, API keys, or personal config files
