### PR TITLE
feat: add native file manager integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,24 @@ Key settings in the source files:
 | `MIN_BROWSER_ACTION_AUDIO_LEAD` | `jarvis_web.html` | `0.65` s | Minimum audio buffer lead before spawning Chrome |
 | `PLAYBACK_IDLE_GRACE_MS` | `jarvis_web.html` | `220` ms | Grace period after last audio chunk before marking idle |
 
+### Local file manager API
+
+The launcher also exposes safe local file helpers on `localhost:8766` for native file manager integration:
+
+```bash
+curl -X POST http://localhost:8766/open_path \
+  -H "Content-Type: application/json" \
+  -d '{"path":"/path/to/project"}'
+
+curl -X POST http://localhost:8766/reveal_path \
+  -H "Content-Type: application/json" \
+  -d '{"path":"/path/to/project/report.pdf"}'
+```
+
+- `/open_path` opens a file with the default app or a directory in the native file manager.
+- `/reveal_path` opens the containing directory and selects the file where the OS supports it.
+- Missing or empty paths are rejected with a JSON error instead of being passed to the shell.
+
 ---
 
 ## 🗂️ Project Structure
@@ -426,6 +444,7 @@ Key settings in the source files:
 ```
 toingg-jarvis/
 ├── 🐍 jarvis_launcher.py     # Wake-word listener, app launcher, HTTP server (:8766)
+├── 🐍 native_file_manager.py # Cross-platform local file/folder opener
 ├── 🐍 browserClient.py       # Playwright browser automation client
 ├── 🌐 jarvis_web.html         # Web frontend — WebSocket audio, terminal UI
 ├── 🎨 jarvis_visual.html      # Animated orb / visual display

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -16,6 +16,8 @@ import os, sys, time, threading, subprocess, tempfile, json, webbrowser
 import ctypes, ctypes.wintypes
 import platform as _plat
 
+from native_file_manager import FileManagerError, open_in_file_manager
+
 # ── CONFIG ────────────────────────────────────────────────────────────────────
 _DIR        = os.path.dirname(os.path.abspath(__file__))
 WEB_HTML    = os.path.join(_DIR, "jarvis_web.html")
@@ -613,6 +615,28 @@ def start_http_server():
                 self._cors()
                 self.end_headers()
                 self.wfile.write(b'{"ok":true}')
+
+            elif self.path in ("/open_path", "/reveal_path"):
+                try:
+                    payload = json.loads(body) if body else {}
+                    if not isinstance(payload, dict):
+                        raise FileManagerError("JSON object payload required")
+                    path = str(payload.get("path") or "").strip()
+                    action = "reveal" if self.path == "/reveal_path" else payload.get("action", "open")
+                    open_in_file_manager(path, action=action)
+                    print(f"  [files] ✅ {action} {path}")
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(b'{"ok":true}')
+                except Exception as e:
+                    print(f"  [files] ⚠  open path error: {e}")
+                    self.send_response(400)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error": str(e)}).encode())
 
             elif self.path == "/config":
                 try:

--- a/native_file_manager.py
+++ b/native_file_manager.py
@@ -1,0 +1,76 @@
+"""Cross-platform helpers for opening local files and directories.
+
+The launcher uses these helpers to integrate with the operating system's
+native file manager without depending on a GUI toolkit.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+from pathlib import Path
+from typing import Literal
+
+FileManagerAction = Literal["open", "reveal"]
+
+
+class FileManagerError(ValueError):
+    """Raised when a file-manager request cannot be handled safely."""
+
+
+def _resolve_existing_path(path: str | os.PathLike[str]) -> Path:
+    if path is None:
+        raise FileManagerError("path is required")
+
+    raw = str(path).strip()
+    if not raw:
+        raise FileManagerError("path is required")
+
+    resolved = Path(raw).expanduser().resolve()
+    if not resolved.exists():
+        raise FileManagerError(f"path does not exist: {resolved}")
+    return resolved
+
+
+def build_file_manager_command(
+    path: str | os.PathLike[str],
+    action: FileManagerAction = "open",
+    system: str | None = None,
+) -> list[str]:
+    """Return the native command for opening or revealing a local path.
+
+    ``action='open'`` opens files with the default app and directories in the
+    file manager. ``action='reveal'`` opens the containing folder and selects
+    the file when the platform supports selection.
+    """
+
+    if action not in {"open", "reveal"}:
+        raise FileManagerError("action must be 'open' or 'reveal'")
+
+    resolved = _resolve_existing_path(path)
+    system = system or platform.system()
+
+    if system == "Windows":
+        if action == "reveal" and resolved.is_file():
+            return ["explorer", f"/select,{resolved}"]
+        return ["explorer", str(resolved)]
+
+    if system == "Darwin":
+        if action == "reveal":
+            return ["open", "-R", str(resolved)]
+        return ["open", str(resolved)]
+
+    if action == "reveal" and resolved.is_file():
+        resolved = resolved.parent
+    return ["xdg-open", str(resolved)]
+
+
+def open_in_file_manager(
+    path: str | os.PathLike[str],
+    action: FileManagerAction = "open",
+) -> subprocess.Popen:
+    """Launch the native file manager/default app for ``path``."""
+
+    command = build_file_manager_command(path, action=action)
+    return subprocess.Popen(command)

--- a/test_native_file_manager.py
+++ b/test_native_file_manager.py
@@ -1,0 +1,52 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from native_file_manager import (
+    FileManagerError,
+    build_file_manager_command,
+    open_in_file_manager,
+)
+
+
+class NativeFileManagerTests(unittest.TestCase):
+    def test_windows_reveal_selects_existing_file(self):
+        with tempfile.NamedTemporaryFile() as tmp:
+            command = build_file_manager_command(tmp.name, action="reveal", system="Windows")
+
+        self.assertEqual(command[0], "explorer")
+        self.assertTrue(command[1].startswith("/select,"))
+        self.assertIn(Path(tmp.name).name, command[1])
+
+    def test_macos_reveal_uses_open_r(self):
+        with tempfile.NamedTemporaryFile() as tmp:
+            command = build_file_manager_command(tmp.name, action="reveal", system="Darwin")
+
+        self.assertEqual(command, ["open", "-R", str(Path(tmp.name).resolve())])
+
+    def test_linux_reveal_opens_parent_directory_for_files(self):
+        with tempfile.NamedTemporaryFile() as tmp:
+            command = build_file_manager_command(tmp.name, action="reveal", system="Linux")
+
+        self.assertEqual(command, ["xdg-open", str(Path(tmp.name).resolve().parent)])
+
+    def test_open_directory_uses_platform_file_manager(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            command = build_file_manager_command(tmp, system="Linux")
+
+        self.assertEqual(command, ["xdg-open", str(Path(tmp).resolve())])
+
+    def test_missing_path_is_rejected(self):
+        with self.assertRaises(FileManagerError):
+            build_file_manager_command("/definitely/not/here")
+
+    def test_open_in_file_manager_launches_built_command(self):
+        with tempfile.TemporaryDirectory() as tmp, mock.patch("subprocess.Popen") as popen:
+            open_in_file_manager(tmp)
+
+        popen.assert_called_once_with(["xdg-open", str(Path(tmp).resolve())])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #9

## Summary
- add a small cross-platform native file manager helper for opening directories/files and revealing files
- expose `/open_path` and `/reveal_path` on the existing localhost launcher server
- document the local API and add regression tests for Windows, macOS, and Linux command generation

## Test plan
- `python3 -m unittest -v test_native_file_manager.py`
- `python3 -m py_compile jarvis_launcher.py native_file_manager.py browserClient.py`
- `python3 -m unittest discover -v`
