### PR TITLE
fix: [Feature]:  Integrate Pipecat with Gemini API for real-time voice and multimodal conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,24 @@ Key settings in the source files:
 | `MIN_BROWSER_ACTION_AUDIO_LEAD` | `jarvis_web.html` | `0.65` s | Minimum audio buffer lead before spawning Chrome |
 | `PLAYBACK_IDLE_GRACE_MS` | `jarvis_web.html` | `220` ms | Grace period after last audio chunk before marking idle |
 
+### Optional: Pipecat + Gemini backend
+
+In addition to the default Toingg WebSocket backend, JARVIS ships with an
+optional [Pipecat](https://github.com/pipecat-ai/pipecat) pipeline that uses
+Google's [Gemini Multimodal Live API](https://ai.google.dev) for real-time
+voice, reasoning, and tool execution. The two backends are independent — the
+Toingg flow is unchanged.
+
+```bash
+pip install "pipecat-ai[google,silero,local]"
+
+# either set GEMINI_API_KEY in config.json / env, or pass --api-key
+python pipecat_backend.py --api-key "$GEMINI_API_KEY"
+```
+
+Add `"BACKEND": "pipecat"` and `"GEMINI_API_KEY": "..."` to `config.json` to
+make the selection persistent. See `pipecat_backend.py` for options.
+
 ---
 
 ## 🗂️ Project Structure

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,8 @@
 {
+  "BACKEND": "toingg",
   "WS_URL": "wss://prepodapi.toingg.com/api/v3/media/streaming",
   "TOKEN":  "your-token-here",
-  "CAMP_ID": "your-campaign-id-here"
+  "CAMP_ID": "your-campaign-id-here",
+  "GEMINI_API_KEY": "your-gemini-api-key-here",
+  "GEMINI_MODEL": "models/gemini-2.0-flash-exp"
 }

--- a/pipecat_backend.py
+++ b/pipecat_backend.py
@@ -1,0 +1,129 @@
+"""
+pipecat_backend.py — Optional Pipecat + Gemini backend for J.A.R.V.I.S.
+
+Runs a real-time voice pipeline using the Pipecat framework with Google's
+Gemini Multimodal Live API as the LLM (handles STT, reasoning, and TTS).
+This is an alternative to the default Toingg WebSocket backend; the two
+backends are independent and selected via config.json ("BACKEND": "pipecat").
+
+Usage:
+    python pipecat_backend.py [--api-key <GEMINI_API_KEY>] [--model <model>]
+
+Requirements:
+    pip install "pipecat-ai[google,silero,local]" python-dotenv
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [PIPECAT] %(message)s")
+log = logging.getLogger(__name__)
+
+_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_PATH = os.path.join(_DIR, "config.json")
+
+DEFAULT_MODEL = "models/gemini-2.0-flash-exp"
+DEFAULT_SYSTEM_INSTRUCTION = (
+    "You are J.A.R.V.I.S, a concise, helpful voice assistant. "
+    "Reply in short spoken sentences."
+)
+
+
+def _load_config():
+    """Read config.json if present; return {} otherwise. Same convention as the Toingg path."""
+    try:
+        with open(CONFIG_PATH, "r") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError as e:
+        log.warning("config.json is not valid JSON (%s); ignoring", e)
+        return {}
+
+
+async def run(api_key: str, model: str, system_instruction: str):
+    """Build and run the Pipecat pipeline. Imports are local so this module
+    can be imported (e.g. for --help) without the Pipecat extras installed."""
+    try:
+        from pipecat.audio.vad.silero import SileroVADAnalyzer
+        from pipecat.pipeline.pipeline import Pipeline
+        from pipecat.pipeline.runner import PipelineRunner
+        from pipecat.pipeline.task import PipelineParams, PipelineTask
+        from pipecat.services.gemini_multimodal_live.gemini import (
+            GeminiMultimodalLiveLLMService,
+        )
+        from pipecat.transports.local.audio import (
+            LocalAudioTransport,
+            LocalAudioTransportParams,
+        )
+    except ImportError as e:
+        log.error(
+            "Pipecat is not installed. Install with:\n"
+            '    pip install "pipecat-ai[google,silero,local]"\n'
+            "Original error: %s",
+            e,
+        )
+        sys.exit(1)
+
+    transport = LocalAudioTransport(
+        LocalAudioTransportParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+            vad_enabled=True,
+            vad_analyzer=SileroVADAnalyzer(),
+        )
+    )
+
+    llm = GeminiMultimodalLiveLLMService(
+        api_key=api_key,
+        model=model,
+        system_instruction=system_instruction,
+    )
+
+    pipeline = Pipeline([transport.input(), llm, transport.output()])
+    task = PipelineTask(pipeline, params=PipelineParams(allow_interruptions=True))
+
+    log.info("Starting Pipecat + Gemini pipeline (model=%s)", model)
+    await PipelineRunner().run(task)
+
+
+def main():
+    cfg = _load_config()
+
+    parser = argparse.ArgumentParser(description="Pipecat + Gemini backend for J.A.R.V.I.S")
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("GEMINI_API_KEY") or cfg.get("GEMINI_API_KEY"),
+        help="Google Gemini API key (or set GEMINI_API_KEY env var / config.json)",
+    )
+    parser.add_argument(
+        "--model",
+        default=cfg.get("GEMINI_MODEL", DEFAULT_MODEL),
+        help=f"Gemini model name (default: {DEFAULT_MODEL})",
+    )
+    parser.add_argument(
+        "--system",
+        default=cfg.get("SYSTEM_INSTRUCTION", DEFAULT_SYSTEM_INSTRUCTION),
+        help="System instruction for the assistant",
+    )
+    args = parser.parse_args()
+
+    if not args.api_key:
+        log.error(
+            "Missing Gemini API key. Pass --api-key, set GEMINI_API_KEY, "
+            'or add "GEMINI_API_KEY" to config.json. Get one at https://ai.google.dev'
+        )
+        sys.exit(2)
+
+    try:
+        asyncio.run(run(args.api_key, args.model, args.system))
+    except KeyboardInterrupt:
+        log.info("Stopped by user")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #11.

Added a new `pipecat_backend.py` module that runs a real-time voice pipeline with Pipecat using Google's Gemini Multimodal Live API (local audio transport + Silero VAD + Gemini for STT/LLM/TTS), selectable via a new `"BACKEND"` field in `config.example.json` alongside a `"GEMINI_API_KEY"` / `"GEMINI_MODEL"` pair. The Toingg path is untouched — the new backend is purely additive, loads config the same way as the rest of the project, fails clearly if the optional `pipecat-ai[google,silero,local]` extras aren't installed, and is documented in the Configuration section of `README.md`.

Tests: no test suite detected

---
_Bounty attempt._