### PR TITLE
fix: [Feature]:  Cross-platform packaging and native installers for Windows, Linux, and macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,129 @@
+name: Build native installers
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to embed in installer filenames (e.g. 1.0.0)'
+        required: false
+        default: '0.0.0'
+
+permissions:
+  contents: write
+
+jobs:
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - id: v
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ github.event.inputs.version || '0.0.0' }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  windows:
+    needs: resolve-version
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install -r packaging/requirements.txt
+      - name: Build with PyInstaller
+        run: pyinstaller --noconfirm packaging/jarvis.spec
+      - name: Install Inno Setup
+        run: choco install innosetup --no-progress -y
+      - name: Build installer
+        shell: pwsh
+        run: |
+          & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" `
+            "/DAppVersion=${{ needs.resolve-version.outputs.version }}" `
+            packaging\windows\installer.iss
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jarvis-windows-installer
+          path: dist/installer/*.exe
+
+  linux:
+    needs: resolve-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev libasound2-dev dpkg-dev
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install -r packaging/requirements.txt
+      - name: Build with PyInstaller
+        run: pyinstaller --noconfirm packaging/jarvis.spec
+      - name: Build .deb
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: bash packaging/linux/build_deb.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jarvis-linux-deb
+          path: dist/deb/*.deb
+
+  macos:
+    needs: resolve-version
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install system deps
+        run: brew install portaudio
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install -r packaging/requirements.txt
+      - name: Build with PyInstaller
+        run: pyinstaller --noconfirm packaging/jarvis.spec
+      - name: Build .dmg
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: bash packaging/macos/build_dmg.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jarvis-macos-dmg
+          path: dist/*.dmg
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [windows, linux, macos]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/jarvis-windows-installer/*.exe
+            artifacts/jarvis-linux-deb/*.deb
+            artifacts/jarvis-macos-dmg/*.dmg

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,38 @@
+# Native installers
+
+Cross-platform packaging for J.A.R.V.I.S. The `.github/workflows/release.yml`
+pipeline runs everything below automatically on every `v*` tag push (and via
+`workflow_dispatch`), uploads per-OS artifacts, and attaches them to the
+GitHub Release.
+
+## Outputs
+
+| OS      | Format             | Built by                                  |
+|---------|--------------------|-------------------------------------------|
+| Windows | `.exe` installer   | PyInstaller + [Inno Setup](https://jrsoftware.org/isinfo.php) |
+| Linux   | `.deb` (Debian/Ubuntu) | PyInstaller + `dpkg-deb`              |
+| macOS   | `.app` bundle + `.dmg` | PyInstaller `BUNDLE` + `hdiutil`      |
+
+## Build locally
+
+```bash
+# 1. One-folder + .app build (current OS)
+pip install pyinstaller -r packaging/requirements.txt
+pyinstaller --noconfirm packaging/jarvis.spec
+
+# 2a. Windows installer (needs Inno Setup 6 on PATH)
+iscc /DAppVersion=1.0.0 packaging\windows\installer.iss
+
+# 2b. Linux .deb
+VERSION=1.0.0 bash packaging/linux/build_deb.sh
+
+# 2c. macOS .dmg
+VERSION=1.0.0 bash packaging/macos/build_dmg.sh
+```
+
+## Signing
+
+The workflow ships unsigned binaries by default. To enable signing, add the
+relevant secrets (`WINDOWS_PFX_BASE64` / `MACOS_DEVELOPER_ID` / `APPLE_API_KEY`)
+and a signing step before the artifact upload — placeholders intentionally
+omitted to keep the default pipeline runnable without secret setup.

--- a/packaging/jarvis.spec
+++ b/packaging/jarvis.spec
@@ -1,0 +1,69 @@
+# PyInstaller spec for J.A.R.V.I.S — builds one-folder app for the current OS.
+# Run from repo root:  pyinstaller packaging/jarvis.spec
+import sys
+from PyInstaller.utils.hooks import collect_submodules
+
+block_cipher = None
+
+datas = [
+    ('jarvis_web.html', '.'),
+    ('jarvis_visual.html', '.'),
+    ('browserClient.py', '.'),
+    ('config.example.json', '.'),
+]
+
+hiddenimports = (
+    collect_submodules('speech_recognition')
+    + collect_submodules('playwright')
+    + ['pyaudio', 'numpy', 'websocket', 'rich', 'sounddevice']
+)
+
+a = Analysis(
+    ['jarvis_launcher.py'],
+    pathex=[],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='JARVIS',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    name='JARVIS',
+)
+
+if sys.platform == 'darwin':
+    app = BUNDLE(
+        coll,
+        name='JARVIS.app',
+        bundle_identifier='com.pgagi.jarvis',
+        info_plist={
+            'NSMicrophoneUsageDescription': 'JARVIS needs microphone access for wake-word detection.',
+            'NSHighResolutionCapable': True,
+            'LSMinimumSystemVersion': '10.14',
+        },
+    )

--- a/packaging/linux/build_deb.sh
+++ b/packaging/linux/build_deb.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Builds a .deb from the PyInstaller one-folder output at dist/JARVIS.
+# Usage:  VERSION=1.0.0 bash packaging/linux/build_deb.sh
+set -euo pipefail
+
+VERSION="${VERSION:-0.0.0}"
+ARCH="${ARCH:-amd64}"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SRC="${ROOT}/dist/JARVIS"
+PKG="${ROOT}/dist/deb/jarvis_${VERSION}_${ARCH}"
+
+if [[ ! -d "$SRC" ]]; then
+    echo "Missing PyInstaller output at $SRC — run 'pyinstaller packaging/jarvis.spec' first." >&2
+    exit 1
+fi
+
+rm -rf "$PKG"
+mkdir -p "$PKG/DEBIAN" "$PKG/opt/jarvis" "$PKG/usr/bin" "$PKG/usr/share/applications"
+
+cp -a "$SRC/." "$PKG/opt/jarvis/"
+
+cat > "$PKG/DEBIAN/control" <<EOF
+Package: jarvis
+Version: ${VERSION}
+Section: utils
+Priority: optional
+Architecture: ${ARCH}
+Depends: libportaudio2, libasound2
+Maintainer: PG-AGI <noreply@pg-agi.example>
+Description: J.A.R.V.I.S voice-activated launcher
+ Wake-word activated launcher that opens the JARVIS web UI in Chrome.
+EOF
+
+cat > "$PKG/usr/bin/jarvis" <<'EOF'
+#!/usr/bin/env bash
+exec /opt/jarvis/JARVIS "$@"
+EOF
+chmod 755 "$PKG/usr/bin/jarvis"
+
+cat > "$PKG/usr/share/applications/jarvis.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=JARVIS
+Comment=Voice-activated JARVIS launcher
+Exec=/opt/jarvis/JARVIS
+Icon=utilities-terminal
+Terminal=true
+Categories=Utility;
+EOF
+
+dpkg-deb --build --root-owner-group "$PKG"
+echo "Built: ${PKG}.deb"

--- a/packaging/macos/build_dmg.sh
+++ b/packaging/macos/build_dmg.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Wraps the PyInstaller-built JARVIS.app into a .dmg.
+# Usage:  VERSION=1.0.0 bash packaging/macos/build_dmg.sh
+set -euo pipefail
+
+VERSION="${VERSION:-0.0.0}"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+APP="${ROOT}/dist/JARVIS.app"
+OUT_DIR="${ROOT}/dist"
+DMG="${OUT_DIR}/JARVIS-${VERSION}.dmg"
+STAGE="${OUT_DIR}/dmg-stage"
+
+if [[ ! -d "$APP" ]]; then
+    echo "Missing $APP — run 'pyinstaller packaging/jarvis.spec' on macOS first." >&2
+    exit 1
+fi
+
+rm -rf "$STAGE" "$DMG"
+mkdir -p "$STAGE"
+cp -R "$APP" "$STAGE/"
+ln -s /Applications "$STAGE/Applications"
+
+hdiutil create \
+    -volname "JARVIS ${VERSION}" \
+    -srcfolder "$STAGE" \
+    -ov -format UDZO \
+    "$DMG"
+
+rm -rf "$STAGE"
+echo "Built: $DMG"

--- a/packaging/requirements.txt
+++ b/packaging/requirements.txt
@@ -1,0 +1,8 @@
+pyaudio
+numpy
+websocket-client
+rich
+SpeechRecognition
+playwright
+playwright-stealth
+sounddevice

--- a/packaging/windows/installer.iss
+++ b/packaging/windows/installer.iss
@@ -1,0 +1,46 @@
+; Inno Setup script for J.A.R.V.I.S — builds a one-click Windows installer.
+; Compile with:  iscc packaging\windows\installer.iss
+; Expects PyInstaller output at dist\JARVIS\ (built via packaging\jarvis.spec).
+
+#define AppName      "JARVIS"
+#define AppPublisher "PG-AGI"
+#define AppURL       "https://github.com/PG-AGI/toingg-jarvis"
+#define AppExeName   "JARVIS.exe"
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+
+[Setup]
+AppId={{B7E1F9F0-6F4A-4F6A-9A60-7D0B8C6E2B11}}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppPublisher={#AppPublisher}
+AppPublisherURL={#AppURL}
+DefaultDirName={autopf}\{#AppName}
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+UninstallDisplayIcon={app}\{#AppExeName}
+OutputDir=..\..\dist\installer
+OutputBaseFilename=JARVIS-Setup-{#AppVersion}
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+ArchitecturesInstallIn64BitMode=x64
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional icons:"
+
+[Files]
+Source: "..\..\dist\JARVIS\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#AppExeName}"; Description: "Launch {#AppName}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
Closes #13.

Added a `packaging/` directory with a PyInstaller spec (bundling `jarvis_launcher.py` + HTML assets + `browserClient.py`, plus a macOS `BUNDLE` block for `.app`), an Inno Setup script for the Windows `.exe`, and shell scripts that wrap PyInstaller output into a `.deb` (Debian/Ubuntu) and a `.dmg` (macOS). A new `.github/workflows/release.yml` runs PyInstaller on Windows/Linux/macOS runners, invokes each packager, uploads per-OS artifacts, and on `v*` tags attaches them to a GitHub Release — fulfilling the issue's one-click installer + automated build pipeline ask without touching any existing source files.

Tests: no test suite detected

---
_Bounty attempt._