### PR TITLE
fix: route browser WebSocket payload dumps to debug logging

### DIFF
--- a/browserClient.py
+++ b/browserClient.py
@@ -1182,7 +1182,7 @@ class BrowserClient:
     def _on_message(self, ws, raw: str):
         try:
             msg = json.loads(raw)
-            print("Received: ", msg)
+            log.debug("Received: %s", msg)
         except json.JSONDecodeError:
             return
 


### PR DESCRIPTION
/claim #15

## Linked Issue
Closes #15

## Summary of Changes
- Replaced the unconditional `print("Received: ", msg)` in `browserClient.py` with `log.debug("Received: %s", msg)`
- Keeps full WebSocket payloads out of stdout at the default INFO log level
- Preserves the payload details for developers who explicitly enable DEBUG logging

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / tooling / config change

## Testing Performed
- [x] Tested on **Windows**
- [ ] Tested on **macOS**
- [ ] Tested on **Linux**
- Platform tested on: Windows 11
- Python version: Python 3.x

Steps to verify:
1. `python -m py_compile browserClient.py`
2. Start `browserClient.py` and trigger a browser command
3. Confirm raw WebSocket payload JSON is no longer printed to stdout at default logging settings

## Screenshots / Recordings
Not applicable; logging-only change.

## Reward Points Requested
Points requested: **50**
Justification: Bug fix for noisy/unsafe stdout payload logging.

## Checklist
- [x] My code follows the project's style guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [ ] I have commented any non-obvious logic
- [ ] I have updated relevant documentation (README, JARVIS_README, docstrings)
- [x] My changes do not introduce new warnings or errors
- [x] I have tested this on at least one supported platform
- [x] I have not committed secrets, API keys, or personal config files
