### PR TITLE
Add upload-backed input_file actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,46 @@ python3 jarvis_launcher.py
 
 When JARVIS fetches news, weather, or web results — Chrome windows open automatically in a **2×2 grid** and close after the response finishes.
 
+### Uploading files for browser automation
+
+The local HTTP server accepts standard multipart uploads and returns upload tokens
+that can be passed to Playwright `input_file` actions:
+
+```bash
+curl -F "file=@screenshot.png" http://localhost:8766/api/uploads
+```
+
+Example response:
+
+```json
+{
+  "ok": true,
+  "uploads": [
+    {
+      "token": "4f2a...c9.png",
+      "path": "/path/to/toingg-jarvis/.cache/uploads/4f2a...c9.png",
+      "url": "http://localhost:8766/api/uploads/4f2a...c9.png"
+    }
+  ]
+}
+```
+
+Send the token or returned path in an `input_file` browser action:
+
+```json
+{
+  "action": "input_file",
+  "params": {
+    "selector": "input[type=file]",
+    "upload_token": "4f2a...c9.png"
+  }
+}
+```
+
+Uploaded files are stored under `.cache/uploads`, expire after 30 minutes, and
+are removed automatically after `input_file` uses them unless `cleanup` is set
+to `false`.
+
 ---
 
 ## 📄 Data Requirements

--- a/browserClient.py
+++ b/browserClient.py
@@ -45,6 +45,8 @@ except ImportError:
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [BROWSER] %(message)s")
 log = logging.getLogger(__name__)
 
+UPLOAD_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".cache", "uploads")
+
 # ---------------------------------------------------------------------------
 # Stealth init script — patches common fingerprint leaks that trigger Google
 # ---------------------------------------------------------------------------
@@ -188,6 +190,77 @@ class BrowserClient:
         if len(normalized) <= limit:
             return normalized
         return normalized[: limit - 3] + "..."
+
+    @staticmethod
+    def _resolve_file_reference(value: str) -> str:
+        """Resolve an upload token or local path into a file path for Playwright."""
+        if not value:
+            raise ValueError("file reference is empty")
+
+        raw = str(value)
+        if raw.startswith("upload:"):
+            raw = raw.split(":", 1)[1]
+
+        local_path = os.path.abspath(os.path.expanduser(raw))
+        if os.path.isfile(local_path):
+            return local_path
+
+        token = os.path.basename(raw)
+        if not token or token in {".", ".."} or token != raw:
+            raise ValueError(f"invalid upload token or file path: {value}")
+
+        upload_path = os.path.abspath(os.path.join(UPLOAD_DIR, token))
+        upload_root = os.path.abspath(UPLOAD_DIR)
+        if os.path.commonpath([upload_root, upload_path]) != upload_root:
+            raise ValueError(f"invalid upload token: {value}")
+        if not os.path.isfile(upload_path):
+            raise FileNotFoundError(f"upload token not found: {value}")
+        return upload_path
+
+    @staticmethod
+    def _is_managed_upload(path: str) -> bool:
+        upload_root = os.path.abspath(UPLOAD_DIR)
+        candidate = os.path.abspath(path)
+        return os.path.commonpath([upload_root, candidate]) == upload_root
+
+    def _input_files(self, selector: str, params: dict) -> str:
+        references = (
+            params.get("paths")
+            or params.get("files")
+            or params.get("upload_tokens")
+            or params.get("tokens")
+        )
+        if references is None:
+            single = (
+                params.get("path")
+                or params.get("file")
+                or params.get("upload_token")
+                or params.get("token")
+            )
+            references = [single]
+        elif isinstance(references, str):
+            references = [references]
+
+        resolved = [self._resolve_file_reference(item) for item in references if item]
+        if not resolved:
+            raise ValueError("input_file requires at least one path or upload token")
+
+        page = self.page
+        if page is None:
+            raise RuntimeError("Browser page not initialised")
+
+        page.set_input_files(selector, resolved, timeout=params.get("timeout", 10000))
+
+        if params.get("cleanup", True):
+            for path in resolved:
+                if self._is_managed_upload(path):
+                    try:
+                        os.remove(path)
+                    except OSError:
+                        pass
+
+        noun = "file" if len(resolved) == 1 else "files"
+        return f"Attached {len(resolved)} {noun} to '{selector}'"
 
     def _click_element(self, selector: str, timeout: int, force: bool = False) -> str:
         page = self.page
@@ -1044,6 +1117,12 @@ class BrowserClient:
                 self._human_delay()
                 page.select_option(selector, value)
                 return {"success": True, "result": f"Selected '{value}' in '{selector}'"}
+
+            elif action == "input_file":
+                selector = params["selector"]
+                self._human_delay(80, 250)
+                result = self._input_files(selector, params)
+                return {"success": True, "result": result}
 
             elif action == "scroll":
                 x = params.get("x", 0)

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -13,8 +13,11 @@ Requirements:
 """
 
 import os, sys, time, threading, subprocess, tempfile, json, webbrowser
+import io, mimetypes, uuid
 import ctypes, ctypes.wintypes
 import platform as _plat
+from email.parser import BytesParser
+from email.policy import default as email_policy
 
 # ── CONFIG ────────────────────────────────────────────────────────────────────
 _DIR        = os.path.dirname(os.path.abspath(__file__))
@@ -24,6 +27,9 @@ BROWSER_CLIENT = os.path.join(_DIR, "browserClient.py")
 WAKE_WORDS  = ["hey jarvis", "jarvis", "hey jervis", "hey davis"]
 LAUNCH_COOLDOWN = 4.0
 HTTP_PORT   = 8766
+UPLOAD_DIR  = os.path.join(_DIR, ".cache", "uploads")
+UPLOAD_TTL_SECONDS = 30 * 60
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 
 # ── shared state (jarvis_web.html POSTs here; jarvis_visual.html polls here) ─
 _http_state      = {"state": "initializing", "text": "", "status": "INITIALIZING..."}
@@ -39,6 +45,62 @@ _url_slot      = 0
 _url_slot_wins = {}
 _url_slot_modes = {}
 _slot_profiles = {}
+
+def _ensure_upload_dir():
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+def _cleanup_expired_uploads():
+    _ensure_upload_dir()
+    now = time.time()
+    for name in os.listdir(UPLOAD_DIR):
+        path = os.path.join(UPLOAD_DIR, name)
+        try:
+            if os.path.isfile(path) and now - os.path.getmtime(path) > UPLOAD_TTL_SECONDS:
+                os.remove(path)
+        except OSError:
+            pass
+
+def _safe_upload_extension(filename, content_type=""):
+    ext = os.path.splitext(filename or "")[1].lower()
+    if ext and ext.replace(".", "").isalnum() and len(ext) <= 12:
+        return ext
+    guessed = mimetypes.guess_extension(content_type or "")
+    return guessed if guessed and len(guessed) <= 12 else ".bin"
+
+def _store_upload(filename, content_type, source):
+    _cleanup_expired_uploads()
+    token = f"{uuid.uuid4().hex}{_safe_upload_extension(filename, content_type)}"
+    path = os.path.join(UPLOAD_DIR, token)
+    written = 0
+    with open(path, "wb") as out:
+        while True:
+            chunk = source.read(1024 * 1024)
+            if not chunk:
+                break
+            written += len(chunk)
+            if written > MAX_UPLOAD_BYTES:
+                out.close()
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+                raise ValueError(f"upload exceeds {MAX_UPLOAD_BYTES // (1024 * 1024)} MB limit")
+            out.write(chunk)
+    if written == 0:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        raise ValueError("uploaded file is empty")
+    return {
+        "token": token,
+        "path": path,
+        "url": f"http://localhost:{HTTP_PORT}/api/uploads/{token}",
+        "filename": os.path.basename(filename or token),
+        "content_type": content_type or "application/octet-stream",
+        "size": written,
+        "expires_in_seconds": UPLOAD_TTL_SECONDS,
+    }
 
 # ── APP REGISTRY ──────────────────────────────────────────────────────────────
 _IS_MAC = _plat.system() == "Darwin"
@@ -500,6 +562,39 @@ def start_http_server():
             self.send_header("Access-Control-Allow-Headers", "Content-Type")
             self.send_header("Cache-Control", "no-store")
 
+        def _send_json(self, status, payload):
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self._cors()
+            self.end_headers()
+            self.wfile.write(json.dumps(payload).encode())
+
+        def _handle_upload(self, body):
+            content_type = self.headers.get("Content-Type", "")
+            if not content_type.lower().startswith("multipart/form-data"):
+                raise ValueError("expected multipart/form-data")
+
+            raw = f"Content-Type: {content_type}\n\n".encode() + body
+            form = BytesParser(policy=email_policy).parsebytes(raw)
+            uploads = []
+            for field in form.iter_parts():
+                filename = field.get_filename()
+                if not filename:
+                    continue
+                payload = field.get_payload(decode=True)
+                if payload is None:
+                    payload = b""
+                uploads.append(
+                    _store_upload(
+                        filename,
+                        field.get_content_type(),
+                        io.BytesIO(payload),
+                    )
+                )
+            if not uploads:
+                raise ValueError("no file fields found in upload")
+            return uploads
+
         def do_OPTIONS(self):
             self.send_response(200)
             self._cors()
@@ -524,6 +619,15 @@ def start_http_server():
                 self._serve_file(VISUAL_HTML)
             elif self.path == "/config.json":
                 self._serve_file(os.path.join(_DIR, "config.json"), "application/json")
+            elif self.path.startswith("/api/uploads/"):
+                _cleanup_expired_uploads()
+                token = os.path.basename(self.path.split("?", 1)[0])
+                path = os.path.join(UPLOAD_DIR, token)
+                if not token or not os.path.isfile(path):
+                    self._send_json(404, {"error": "upload not found"})
+                    return
+                ctype = mimetypes.guess_type(path)[0] or "application/octet-stream"
+                self._serve_file(path, ctype)
             elif self.path == "/state":
                 with _http_state_lock:
                     data = json.dumps(_http_state).encode()
@@ -537,10 +641,20 @@ def start_http_server():
 
         def do_POST(self):
             global _url_slot
+            path = self.path.split("?", 1)[0]
             length = int(self.headers.get("Content-Length", 0))
-            body   = self.rfile.read(length) if length else b""
+            body = self.rfile.read(length) if length else b""
 
-            if self.path == "/state":
+            if path == "/api/uploads":
+                try:
+                    uploads = self._handle_upload(body)
+                    self._send_json(201, {"ok": True, "uploads": uploads})
+                    print(f"  [upload] ✅ Stored {len(uploads)} file(s)")
+                except Exception as e:
+                    print(f"  [upload] ⚠  upload error: {e}")
+                    self._send_json(400, {"ok": False, "error": str(e)})
+
+            elif path == "/state":
                 try:
                     payload = json.loads(body) if body else {}
                     with _http_state_lock:
@@ -553,7 +667,7 @@ def start_http_server():
                 self.end_headers()
                 self.wfile.write(b'{"ok":true}')
 
-            elif self.path == "/open_tabs":
+            elif path == "/open_tabs":
                 try:
                     tabs = json.loads(body) if body else []
                     tabs = tabs[:4]
@@ -576,7 +690,7 @@ def start_http_server():
                 self.end_headers()
                 self.wfile.write(b'{"ok":true}')
 
-            elif self.path == "/open_window":
+            elif path == "/open_window":
                 try:
                     tab = json.loads(body) if body else {}
                     url = tab.get("url", tab) if isinstance(tab, dict) else str(tab)
@@ -597,7 +711,7 @@ def start_http_server():
                 self.end_headers()
                 self.wfile.write(b'{"ok":true}')
 
-            elif self.path == "/close_tabs":
+            elif path == "/close_tabs":
                 try:
                     payload = json.loads(body) if body else {}
                 except Exception:
@@ -614,7 +728,7 @@ def start_http_server():
                 self.end_headers()
                 self.wfile.write(b'{"ok":true}')
 
-            elif self.path == "/config":
+            elif path == "/config":
                 try:
                     payload = json.loads(body) if body else {}
                     token = payload.get("token", "").strip()


### PR DESCRIPTION
## Summary
- adds a local multipart upload endpoint at `POST /api/uploads` that stores temporary files under `.cache/uploads`
- returns upload tokens, paths, and local URLs for uploaded files
- adds browser `input_file` action support for upload tokens or local paths, with automatic cleanup after use
- documents the upload + `input_file` workflow in the README

Closes #6

## Verification
- `python3 -m py_compile jarvis_launcher.py browserClient.py`
- smoke-tested `_store_upload` with an in-memory PNG payload
- smoke-tested `POST /api/uploads` with multipart/form-data; received HTTP 201 and a valid token