### PR TITLE
[codex] Add native file manager path support

### DIFF
--- a/JARVIS_README.md
+++ b/JARVIS_README.md
@@ -96,6 +96,7 @@ CAMP_ID = "your-campaign-id-here"
 - Press **Enter** to speak — JARVIS listens and responds via audio
 - When JARVIS fetches news/weather/war updates, browser tabs open automatically in a 2×2 grid
 - JARVIS can open specific URLs, scrape article details, and close tabs on command
+- JARVIS can open local files and folders with native Explorer/Finder/file-manager integration
 - Press **Ctrl+C** to stop
 
 ---

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ All three layers run simultaneously and communicate over `localhost:8766`.
 - Smart window focus if app is already running
 - Custom window size + positioning per app
 - Platform-aware paths (Windows / macOS / Linux)
+- Open files and folders in the native file manager from voice commands, web UI, or AI path events
 
 </td>
 </tr>
@@ -370,6 +371,8 @@ python3 jarvis_launcher.py
 | Say **"open Spotify"** | Launches Spotify |
 | Say **"open Chrome"** | Launches Chrome |
 | Say **"open VS Code"** | Launches Visual Studio Code |
+| Say **"open downloads"** | Opens a common local folder in the native file manager |
+| Enter a path in **LOCAL PATH** | Opens or reveals a local file/folder from the web UI |
 | **Ctrl+C** in terminal | Exit JARVIS |
 
 When JARVIS fetches news, weather, or web results — Chrome windows open automatically in a **2×2 grid** and close after the response finishes.

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -25,6 +25,14 @@ WAKE_WORDS  = ["hey jarvis", "jarvis", "hey jervis", "hey davis"]
 LAUNCH_COOLDOWN = 4.0
 HTTP_PORT   = 8766
 
+COMMON_PATHS = {
+    "home": lambda: os.path.expanduser("~"),
+    "desktop": lambda: os.path.join(os.path.expanduser("~"), "Desktop"),
+    "downloads": lambda: os.path.join(os.path.expanduser("~"), "Downloads"),
+    "documents": lambda: os.path.join(os.path.expanduser("~"), "Documents"),
+    "pictures": lambda: os.path.join(os.path.expanduser("~"), "Pictures"),
+}
+
 # ── shared state (jarvis_web.html POSTs here; jarvis_visual.html polls here) ─
 _http_state      = {"state": "initializing", "text": "", "status": "INITIALIZING..."}
 _http_state_lock = threading.Lock()
@@ -597,6 +605,31 @@ def start_http_server():
                 self.end_headers()
                 self.wfile.write(b'{"ok":true}')
 
+            elif self.path == "/open_path":
+                try:
+                    payload = json.loads(body) if body else {}
+                    if isinstance(payload, str):
+                        payload = {"path": payload}
+                    if not isinstance(payload, dict):
+                        raise ValueError("expected a JSON object or path string")
+                    result = open_native_path(payload.get("path", ""), payload.get("mode", "open"))
+                    self.send_response(200 if result.get("ok") else 400)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(json.dumps(result).encode())
+                    if result.get("ok"):
+                        print(f"  [file] ok {result.get('mode')} {result.get('path')}")
+                    else:
+                        print(f"  [file] error {result.get('error')}")
+                except Exception as e:
+                    print(f"  [file] open_path error: {e}")
+                    self.send_response(400)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"ok": False, "error": str(e)}).encode())
+
             elif self.path == "/close_tabs":
                 try:
                     payload = json.loads(body) if body else {}
@@ -663,6 +696,88 @@ def start_http_server():
 def resolve_path(path):
     user = os.environ.get("USERNAME", os.environ.get("USER", ""))
     return path.replace("{user}", user)
+
+def resolve_native_path(path=""):
+    if path is None:
+        path = ""
+    path = str(path).strip().strip('"').strip("'")
+    alias = path.lower().replace("\\", "/").strip()
+    if not alias:
+        alias = "home"
+    if alias in COMMON_PATHS:
+        path = COMMON_PATHS[alias]()
+    path = resolve_path(path)
+    path = os.path.expandvars(os.path.expanduser(path))
+    if not os.path.isabs(path):
+        path = os.path.abspath(path)
+    return path
+
+def open_native_path(path="", mode="open"):
+    path = resolve_native_path(path)
+    if not os.path.exists(path):
+        return {"ok": False, "error": f"Path not found: {path}"}
+
+    mode = (mode or "open").lower()
+    system = _plat.system()
+    target = path
+
+    if mode in ("folder", "directory", "browse"):
+        target = path if os.path.isdir(path) else os.path.dirname(path)
+        mode = "open"
+
+    try:
+        if mode in ("reveal", "show", "select"):
+            if system == "Windows":
+                if os.path.isdir(path):
+                    subprocess.Popen(["explorer", path])
+                else:
+                    subprocess.Popen(["explorer", f"/select,{path}"])
+            elif system == "Darwin":
+                if os.path.isdir(path):
+                    subprocess.Popen(["open", path])
+                else:
+                    subprocess.Popen(["open", "-R", path])
+            else:
+                subprocess.Popen(["xdg-open", path if os.path.isdir(path) else os.path.dirname(path)])
+        else:
+            if system == "Windows":
+                os.startfile(target)  # type: ignore[attr-defined]
+            elif system == "Darwin":
+                subprocess.Popen(["open", target])
+            else:
+                subprocess.Popen(["xdg-open", target])
+        return {"ok": True, "path": path, "mode": mode}
+    except Exception as e:
+        return {"ok": False, "error": str(e), "path": path}
+
+def parse_file_command(raw_text):
+    raw_text = raw_text.strip()
+    text = raw_text.lower()
+    mode = "reveal" if any(w in text for w in ("reveal", "show in folder", "show in finder", "show in explorer")) else "open"
+
+    for alias in COMMON_PATHS:
+        phrases = (
+            f"open {alias}", f"open my {alias}", f"open the {alias}",
+            f"show {alias}", f"show my {alias}", f"show the {alias}",
+            f"reveal {alias}", f"go to {alias}", f"navigate to {alias}",
+        )
+        if any(p in text for p in phrases):
+            return alias, mode
+
+    if text in ("open file explorer", "open explorer", "open finder", "open file manager"):
+        return "home", "open"
+
+    prefixes = (
+        "open file", "open folder", "open directory", "open path",
+        "open local file", "open local folder",
+        "show file", "show folder", "show directory", "show path",
+        "reveal file", "reveal folder", "reveal directory", "reveal path",
+        "navigate to", "go to folder",
+    )
+    for prefix in prefixes:
+        if text.startswith(prefix + " "):
+            return raw_text[len(prefix):].strip(), mode
+    return None, None
 
 def find_running_pid(exe_name):
     try:
@@ -811,8 +926,14 @@ def full_launch(source):
     threading.Thread(target=sequence, daemon=True).start()
 
 def handle_command(text):
-    text = text.lower().strip()
+    raw_text = text.strip()
+    text = raw_text.lower().strip()
     print(f"  [cmd] Heard: \"{text}\"")
+    path, mode = parse_file_command(raw_text)
+    if path:
+        print(f"  [cmd] {mode} path: {path}")
+        threading.Thread(target=open_native_path, args=(path, mode), daemon=True).start()
+        return
     if any(w in text for w in WAKE_WORDS) and "open" not in text:
         print("  [cmd] ✅ Wake word → full launch")
         full_launch("wake word")

--- a/jarvis_web.html
+++ b/jarvis_web.html
@@ -233,6 +233,54 @@ html, body {
 .url-link-row a:hover { color:var(--cyan); border-bottom-color:var(--cyan); }
 .url-link-status { color:var(--dim); font-size:10px; min-width:60px; text-align:right; }
 
+/* local file manager */
+#file-bar {
+  flex-shrink:0;
+  background:#000d1a;
+  border:1px solid #123252;
+  border-radius:3px;
+  padding:5px 8px;
+  margin:2px 0;
+}
+#file-bar-label {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  color:var(--dim);
+  font-size:10px;
+  letter-spacing:2px;
+  margin-bottom:4px;
+}
+#file-controls {
+  display:grid;
+  grid-template-columns:1fr auto auto;
+  gap:5px;
+}
+#file-path-input {
+  min-width:0;
+  background:#001020;
+  border:1px solid var(--dim2);
+  color:var(--cyan);
+  font-family:inherit;
+  font-size:10px;
+  padding:4px 6px;
+  border-radius:2px;
+  outline:none;
+}
+#file-path-input:focus { border-color:var(--cyan2); }
+#file-controls button {
+  background:none;
+  border:1px solid var(--cyan2);
+  color:var(--cyan2);
+  font-family:inherit;
+  font-size:10px;
+  padding:3px 7px;
+  cursor:pointer;
+  border-radius:2px;
+}
+#file-controls button:hover { color:var(--cyan); border-color:var(--cyan); background:#002030; }
+#file-status { color:var(--dim); letter-spacing:0; }
+
 /* ── API key setup overlay ── */
 #setup-overlay {
   display:none;
@@ -371,6 +419,18 @@ html, body {
       <button onclick="closeAllTabs()" title="Close all tabs">✕ CLOSE ALL</button>
     </div>
     <div id="url-links"></div>
+  </div>
+
+  <div id="file-bar">
+    <div id="file-bar-label">
+      <span>LOCAL PATH</span>
+      <span id="file-status">READY</span>
+    </div>
+    <div id="file-controls">
+      <input id="file-path-input" type="text" placeholder="desktop, downloads, or C:\path\file.txt" spellcheck="false" />
+      <button onclick="openLocalPath('open')" title="Open file or folder">OPEN</button>
+      <button onclick="openLocalPath('reveal')" title="Show file in native file manager">SHOW</button>
+    </div>
   </div>
 
   <!-- STATUS -->
@@ -924,6 +984,8 @@ const SERVER = "http://localhost:8766";
 
 const urlBarEl    = document.getElementById("url-bar");
 const urlLinksEl  = document.getElementById("url-links");
+const filePathInput = document.getElementById("file-path-input");
+const fileStatusEl  = document.getElementById("file-status");
 
 function isCampaignDashboardLabel(label) {
   return String(label || "").trim().toLowerCase() === "campaign dashboard";
@@ -1085,6 +1147,39 @@ async function closeAllTabs() {
   try {
     await fetch(`${SERVER}/close_tabs`, { method: "POST", body: "" });
   } catch (_) {}
+}
+
+async function openLocalPath(mode = "open", pathOverride = "") {
+  const path = String(pathOverride || filePathInput?.value || "").trim() || "home";
+  if (pathOverride && filePathInput) filePathInput.value = path;
+  if (fileStatusEl) fileStatusEl.textContent = mode === "reveal" ? "SHOWING" : "OPENING";
+  try {
+    const res = await fetch(`${SERVER}/open_path`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path, mode }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || data.ok === false) {
+      const err = data.error || "Path could not be opened";
+      if (fileStatusEl) fileStatusEl.textContent = "ERROR";
+      logChat("sys", `LOCAL PATH ERROR: ${err}`);
+      return false;
+    }
+    if (fileStatusEl) fileStatusEl.textContent = mode === "reveal" ? "SHOWN" : "OPENED";
+    logChat("sys", `LOCAL PATH ${mode.toUpperCase()}: ${data.path || path}`);
+    return true;
+  } catch (_) {
+    if (fileStatusEl) fileStatusEl.textContent = "OFFLINE";
+    logChat("sys", "LOCAL PATH ERROR: launcher server is not reachable");
+    return false;
+  }
+}
+
+if (filePathInput) {
+  filePathInput.addEventListener("keydown", (ev) => {
+    if (ev.key === "Enter") openLocalPath("open");
+  });
 }
 
 // ═══════════════════════════════════════════════════════════════════
@@ -1495,6 +1590,14 @@ function connectWs() {
         pendingUrls.push(item);
         logChat("sys", `◈ OPEN TAB: ${label.slice(0, 60)} — queued`);
         showUrlBar(pendingUrls);  // refresh bar with all pending
+      }
+
+    } else if (ev === "open_local_path" || ev === "open_path" || ev === "weestream_local_path") {
+      const path = msg.path || msg.file || msg.folder || msg.directory || "";
+      const mode = msg.mode || (msg.reveal ? "reveal" : "open");
+      if (path) {
+        logChat("sys", `LOCAL PATH: ${String(path).slice(0, 80)}`);
+        openLocalPath(mode, path);
       }
 
     } else if (ev === "close_all_tabs") {


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #9

---

## Summary of Changes

- Adds a cross-platform `/open_path` launcher endpoint for files, folders, common directories, and show-in-file-manager behavior.
- Adds LOCAL PATH controls in the web UI plus WebSocket path-opening events for assistant-driven file/folder access.
- Adds voice command parsing for common folders and explicit local path phrases, and documents the new workflow.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / tooling / config change

---

## Testing Performed

- [ ] Tested on **Windows**
- [ ] Tested on **macOS**
- [ ] Tested on **Linux**
- Platform tested on: Windows shell environment
- Python version: Not available in this environment (Windows Store python alias only)

Steps to verify:

1. Ran `git diff --check`.
2. Ran a Node-based syntax check over inline scripts in `jarvis_web.html` (`script 1: ok`).
3. Reviewed local path command parsing and `/open_path` routing statically; did not launch the native file manager from this environment.

---

## Screenshots / Recordings

Not applicable.

---

## Reward Points Requested

Points requested: **100**
Justification: Small feature implementation for the approved `$5` bounty in #9.

---

## Checklist

- [x] My code follows the project's style guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] I have commented any non-obvious logic
- [x] I have updated relevant documentation (README, JARVIS_README, docstrings)
- [x] My changes do not introduce new warnings or errors
- [ ] I have tested this on at least one supported platform
- [x] I have not committed secrets, API keys, or personal config files