### PR TITLE
Add upload-backed input_file browser actions

### DIFF
--- a/browserClient.py
+++ b/browserClient.py
@@ -21,6 +21,8 @@ import sys
 import threading
 import time
 import base64
+from urllib.parse import quote
+from urllib.request import ProxyHandler, build_opener
 
 import websocket
 from playwright.sync_api import sync_playwright, Page, Playwright
@@ -44,6 +46,10 @@ except ImportError:
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [BROWSER] %(message)s")
 log = logging.getLogger(__name__)
+UPLOAD_RESOLVE_URL = os.environ.get(
+    "JARVIS_UPLOAD_RESOLVE_URL",
+    "http://localhost:8766/api/uploads",
+)
 
 # ---------------------------------------------------------------------------
 # Stealth init script — patches common fingerprint leaks that trigger Google
@@ -665,6 +671,65 @@ class BrowserClient:
                 return f"Filled '{selector}' with value via {fallback['target']} fallback"
             raise RuntimeError(f"{fill_error}; fallback failed: {fallback.get('error')}")
 
+    def _resolve_upload_token(self, token: str) -> str:
+        url = f"{UPLOAD_RESOLVE_URL.rstrip('/')}/{quote(token)}"
+        opener = build_opener(ProxyHandler({}))
+        with opener.open(url, timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+
+        if not payload.get("ok"):
+            raise RuntimeError(payload.get("error", "Upload token resolution failed"))
+
+        path = payload.get("file", {}).get("path")
+        if not path:
+            raise RuntimeError("Upload token response did not include a file path")
+        return path
+
+    def _input_file_paths(self, params: dict) -> str | list[str]:
+        items = []
+
+        for key in ("path", "file", "token"):
+            if key in params:
+                items.append(params[key])
+
+        for key in ("paths", "files", "tokens"):
+            value = params.get(key)
+            if value is None:
+                continue
+            if isinstance(value, list):
+                items.extend(value)
+            else:
+                items.append(value)
+
+        if not items:
+            raise RuntimeError("input_file requires path/file/token or paths/files/tokens")
+
+        paths = []
+        for item in items:
+            if isinstance(item, dict):
+                if "path" in item:
+                    path = item["path"]
+                elif "token" in item:
+                    path = self._resolve_upload_token(str(item["token"]))
+                else:
+                    raise RuntimeError("input_file file objects must include path or token")
+            elif isinstance(item, str):
+                path = item
+            else:
+                raise RuntimeError("input_file entries must be strings or objects")
+
+            if item == params.get("token") or (
+                isinstance(item, str) and item in params.get("tokens", [])
+            ):
+                path = self._resolve_upload_token(path)
+
+            expanded = os.path.abspath(os.path.expanduser(path))
+            if not os.path.isfile(expanded):
+                raise FileNotFoundError(f"Input file does not exist: {expanded}")
+            paths.append(expanded)
+
+        return paths[0] if len(paths) == 1 else paths
+
     def _execute(self, action: str, params: dict) -> dict:
         """Execute a single Playwright action and return a result dict."""
         page = self._select_active_page()
@@ -708,6 +773,13 @@ class BrowserClient:
                     self._human_delay(100, 400)
                     result = self._fill_field(selector, value, params.get("timeout", 10000))
                 return {"success": True, "result": result}
+
+            elif action in ("input_file", "set_input_files"):
+                selector = params["selector"]
+                files = self._input_file_paths(params)
+                page.locator(selector).set_input_files(files, timeout=params.get("timeout", 10000))
+                count = len(files) if isinstance(files, list) else 1
+                return {"success": True, "result": f"Set {count} file(s) on '{selector}'"}
 
             elif action == "type":
                 value = params.get("value", params.get("text", ""))

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -12,7 +12,7 @@ Requirements:
     pip install sounddevice numpy speechrecognition
 """
 
-import os, sys, time, threading, subprocess, tempfile, json, webbrowser
+import os, sys, time, threading, subprocess, tempfile, json, webbrowser, uuid
 import ctypes, ctypes.wintypes
 import platform as _plat
 
@@ -28,6 +28,10 @@ HTTP_PORT   = 8766
 # ── shared state (jarvis_web.html POSTs here; jarvis_visual.html polls here) ─
 _http_state      = {"state": "initializing", "text": "", "status": "INITIALIZING..."}
 _http_state_lock = threading.Lock()
+UPLOAD_TTL_SECONDS = 3600
+UPLOAD_DIR = os.path.join(tempfile.gettempdir(), "jarvis_uploads")
+_uploaded_files = {}
+_uploaded_files_lock = threading.Lock()
 
 # ── SLOT WINDOW CONFIG (mirrors jarvis_terminal.py) ───────────────────────────
 URL_WIN_W  = 860
@@ -371,6 +375,88 @@ def close_all_url_windows(auto=False):
         _url_slot_wins.pop(slot, None)
         _url_slot_modes.pop(slot, None)
 
+def _safe_upload_name(filename):
+    name = os.path.basename(str(filename).replace("\\", "/"))
+    cleaned = "".join(ch if ch.isalnum() or ch in ("-", "_", ".") else "_" for ch in name)
+    return cleaned or "upload.bin"
+
+def _cleanup_uploaded_files(now=None):
+    now = now or time.time()
+    expired = []
+    with _uploaded_files_lock:
+        for token, record in list(_uploaded_files.items()):
+            if record["expires_at"] <= now:
+                expired.append((token, record["path"]))
+                _uploaded_files.pop(token, None)
+
+    for _, path in expired:
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+def _parse_multipart_uploads(content_type, body):
+    from email.parser import BytesParser
+    from email.policy import default
+
+    if not content_type.startswith("multipart/form-data"):
+        raise ValueError("Content-Type must be multipart/form-data")
+
+    message = BytesParser(policy=default).parsebytes(
+        f"Content-Type: {content_type}\r\n\r\n".encode("utf-8") + body
+    )
+    if not message.is_multipart():
+        raise ValueError("Multipart payload is invalid")
+
+    files = []
+    for part in message.iter_parts():
+        filename = part.get_filename()
+        if not filename:
+            continue
+        data = part.get_payload(decode=True)
+        if data is None:
+            continue
+        files.append({"filename": _safe_upload_name(filename), "data": data})
+
+    if not files:
+        raise ValueError("No file parts found in upload")
+    return files
+
+def _store_uploaded_files(files):
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    expires_at = time.time() + UPLOAD_TTL_SECONDS
+    stored = []
+
+    with _uploaded_files_lock:
+        for item in files:
+            token = uuid.uuid4().hex
+            path = os.path.join(UPLOAD_DIR, f"{token}_{item['filename']}")
+            with open(path, "wb") as f:
+                f.write(item["data"])
+
+            record = {
+                "token": token,
+                "filename": item["filename"],
+                "path": path,
+                "size": len(item["data"]),
+                "expires_at": expires_at,
+            }
+            _uploaded_files[token] = record
+            stored.append(record.copy())
+
+    return stored
+
+def _uploaded_file_record(token):
+    _cleanup_uploaded_files()
+    with _uploaded_files_lock:
+        record = _uploaded_files.get(token)
+        if record is None:
+            raise FileNotFoundError("Upload token not found or expired")
+        if not os.path.exists(record["path"]):
+            _uploaded_files.pop(token, None)
+            raise FileNotFoundError("Uploaded file is missing")
+        return record.copy()
+
 # ── JARVIS WINDOWS ────────────────────────────────────────────────────────────
 _visual_proc = None
 _web_proc    = None
@@ -500,6 +586,13 @@ def start_http_server():
             self.send_header("Access-Control-Allow-Headers", "Content-Type")
             self.send_header("Cache-Control", "no-store")
 
+        def _json(self, status, payload):
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self._cors()
+            self.end_headers()
+            self.wfile.write(json.dumps(payload).encode("utf-8"))
+
         def do_OPTIONS(self):
             self.send_response(200)
             self._cors()
@@ -532,6 +625,24 @@ def start_http_server():
                 self._cors()
                 self.end_headers()
                 self.wfile.write(data)
+            elif self.path.startswith("/api/uploads/"):
+                from urllib.parse import unquote
+
+                token = unquote(self.path.rsplit("/", 1)[-1])
+                try:
+                    record = _uploaded_file_record(token)
+                    self._json(200, {
+                        "ok": True,
+                        "file": {
+                            "token": record["token"],
+                            "filename": record["filename"],
+                            "path": record["path"],
+                            "size": record["size"],
+                            "expiresAt": record["expires_at"],
+                        },
+                    })
+                except FileNotFoundError as e:
+                    self._json(404, {"ok": False, "error": str(e)})
             else:
                 self.send_response(404); self.end_headers()
 
@@ -642,6 +753,27 @@ def start_http_server():
                     self._cors()
                     self.end_headers()
                     self.wfile.write(json.dumps({"error": str(e)}).encode())
+
+            elif self.path == "/api/uploads":
+                try:
+                    _cleanup_uploaded_files()
+                    files = _parse_multipart_uploads(self.headers.get("Content-Type", ""), body)
+                    stored = _store_uploaded_files(files)
+                    self._json(201, {
+                        "ok": True,
+                        "files": [
+                            {
+                                "token": item["token"],
+                                "filename": item["filename"],
+                                "path": item["path"],
+                                "size": item["size"],
+                                "expiresAt": item["expires_at"],
+                            }
+                            for item in stored
+                        ],
+                    })
+                except ValueError as e:
+                    self._json(400, {"ok": False, "error": str(e)})
 
             else:
                 self.send_response(404); self.end_headers()


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #6

---

## Summary of Changes

- Added `POST /api/uploads` to accept standard `multipart/form-data` file uploads and store them temporarily under a server-side token.
- Added `GET /api/uploads/<token>` so the browser automation client can resolve uploaded files into local paths.
- Added `input_file` / `set_input_files` browser actions that pass local paths or uploaded file tokens into Playwright `set_input_files()`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / tooling / config change

---

## Testing Performed

- [ ] Tested on **Windows**
- [x] Tested on **macOS**
- [ ] Tested on **Linux**
- Platform tested on: macOS, Apple Silicon
- Python version: 3.14.3

Steps to verify:

1. `python3 -m py_compile jarvis_launcher.py browserClient.py`
2. Started the launcher HTTP server on a temporary port and uploaded a text fixture through `POST /api/uploads`.
3. Resolved the returned token through `GET /api/uploads/<token>` and confirmed the stored file content matched the uploaded content.
4. Re-ran token resolution with `ALL_PROXY` set to a bogus proxy to verify local upload lookup bypasses proxy configuration.
5. `git diff --check`

## Screenshots / Recordings

Not applicable; this is local API/browser-action plumbing, not a UI change.

---

## Reward Points Requested

Points requested: **250 base points, before any maintainer-applied multipliers**
Justification: requested feature implementation for the approved, priority-high file upload/input-file workflow. Final point value is at maintainer discretion per `REWARD_SYSTEM.md`.

## Checklist

- [x] My code follows the project's style guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] I have commented any non-obvious logic
- [ ] I have updated relevant documentation (README, JARVIS_README, docstrings)
- [x] My changes do not introduce new warnings or errors
- [x] I have tested this on at least one supported platform
- [x] I have not committed secrets, API keys, or personal config files

