### PR TITLE
feat: add native file manager actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,14 @@ python3 jarvis_launcher.py
 
 When JARVIS fetches news, weather, or web results — Chrome windows open automatically in a **2×2 grid** and close after the response finishes.
 
+Browser automation can also open local files and folders through native OS tools:
+
+```json
+{"action": "open_directory", "params": {"path": "/Users/me/Projects/Jarvis"}}
+{"action": "reveal_file", "params": {"path": "/Users/me/Downloads/report.pdf"}}
+{"action": "open_file", "params": {"path": "/Users/me/Documents/notes.txt"}}
+```
+
 ---
 
 ## 📄 Data Requirements
@@ -503,7 +511,11 @@ JARVIS is composed of three cooperating processes that communicate over `localho
 
 ## 🧪 Testing
 
-There is currently no automated test suite. Contributions adding unit or integration tests are **very welcome** and carry bonus reward points (see [REWARD_SYSTEM.md](REWARD_SYSTEM.md)).
+Run the focused unit tests for local file-manager actions:
+
+```bash
+python3 -m unittest tests.test_file_manager_actions
+```
 
 **Manual smoke-test checklist:**
 

--- a/browserClient.py
+++ b/browserClient.py
@@ -25,6 +25,8 @@ import base64
 import websocket
 from playwright.sync_api import sync_playwright, Page, Playwright
 
+from jarvis_launcher import FILE_MANAGER_ACTIONS, open_local_file_manager
+
 # playwright-stealth >= 2.x uses `Stealth`; older 1.x used `stealth_sync`.
 try:
     from playwright_stealth import Stealth
@@ -667,11 +669,17 @@ class BrowserClient:
 
     def _execute(self, action: str, params: dict) -> dict:
         """Execute a single Playwright action and return a result dict."""
-        page = self._select_active_page()
-        if page is None:
-            return {"success": False, "error": "Browser page not initialised"}
-
         try:
+            if action in FILE_MANAGER_ACTIONS:
+                raw_path = params.get("path")
+                # 文件管理器动作不依赖浏览器页面，先处理可以避免未打开页面时误失败。
+                open_local_file_manager(action, raw_path)
+                return {"success": True, "result": f"Executed {action} for {raw_path}"}
+
+            page = self._select_active_page()
+            if page is None:
+                return {"success": False, "error": "Browser page not initialised"}
+
             if action == "navigate":
                 url = params["url"]
                 page.goto(url, timeout=params.get("timeout", 30000))

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -12,7 +12,7 @@ Requirements:
     pip install sounddevice numpy speechrecognition
 """
 
-import os, sys, time, threading, subprocess, tempfile, json, webbrowser
+import os, sys, time, threading, subprocess, tempfile, json, webbrowser, shutil
 import ctypes, ctypes.wintypes
 import platform as _plat
 
@@ -88,6 +88,60 @@ PROCESS_NAMES = {
     "visual studio code": "Code.exe",
     "spotify":            "Spotify.exe",
 }
+
+FILE_MANAGER_ACTIONS = {"open_directory", "reveal_file", "open_file"}
+
+# ── LOCAL FILE MANAGER ────────────────────────────────────────────────────────
+def _normalize_file_manager_path(raw_path):
+    """Normalize a local path before handing it to the OS file manager."""
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise ValueError("path is required for file manager action")
+
+    # 只展开本机路径，不接受空字符串，避免把错误请求交给系统打开。
+    local_path = os.path.abspath(os.path.expanduser(raw_path.strip()))
+    if not os.path.exists(local_path):
+        raise FileNotFoundError(f"local path does not exist: {local_path}")
+    return local_path
+
+def build_file_manager_command(action, raw_path):
+    """Build the platform command for opening or revealing a local path."""
+    action = str(action or "").strip()
+    if action not in FILE_MANAGER_ACTIONS:
+        raise ValueError(f"unsupported file manager action: {action}")
+
+    local_path = _normalize_file_manager_path(raw_path)
+    if action == "open_directory" and not os.path.isdir(local_path):
+        raise NotADirectoryError(f"directory path required: {local_path}")
+    if action == "open_file" and not os.path.isfile(local_path):
+        raise IsADirectoryError(f"file path required: {local_path}")
+
+    system_name = _plat.system()
+    if system_name == "Darwin":
+        if action == "reveal_file":
+            return ["open", "-R", local_path]
+        return ["open", local_path]
+
+    if system_name == "Windows":
+        if action == "open_directory":
+            return ["explorer", local_path]
+        if action == "reveal_file":
+            return ["explorer", f"/select,{local_path}"]
+        return ["cmd", "/c", "start", "", local_path]
+
+    # Linux 没有统一的“选中文件”协议；有 Nautilus 时优先选中，否则打开所在目录。
+    if action == "reveal_file":
+        if shutil.which("nautilus"):
+            return ["nautilus", "--select", local_path]
+        target_dir = local_path if os.path.isdir(local_path) else os.path.dirname(local_path)
+        return ["xdg-open", target_dir]
+    return ["xdg-open", local_path]
+
+def open_local_file_manager(action, raw_path):
+    """Open the native file manager or default app for a validated local path."""
+    command = build_file_manager_command(action, raw_path)
+    # 这里是真正触发系统外部应用的边界，调用前已完成路径和动作校验。
+    subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return command
 
 # ── CHROME FINDER (cross-platform) ───────────────────────────────────────────
 def find_chrome():
@@ -596,6 +650,27 @@ def start_http_server():
                 self._cors()
                 self.end_headers()
                 self.wfile.write(b'{"ok":true}')
+
+            elif self.path == "/file_manager":
+                try:
+                    payload = json.loads(body) if body else {}
+                    action = payload.get("action")
+                    raw_path = payload.get("path")
+                    # 先校验动作和路径，再异步交给系统文件管理器处理。
+                    open_local_file_manager(action, raw_path)
+                    print(f"  [file] ✅ {action}: {raw_path}")
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(b'{"ok":true}')
+                except Exception as e:
+                    print(f"  [file] ⚠  file_manager error: {e}")
+                    self.send_response(400)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error": str(e)}).encode())
 
             elif self.path == "/close_tabs":
                 try:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# 让 unittest discover 能稳定发现 tests 目录下的测试文件。

--- a/tests/test_file_manager_actions.py
+++ b/tests/test_file_manager_actions.py
@@ -1,0 +1,73 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import jarvis_launcher
+
+
+class FileManagerActionTests(unittest.TestCase):
+    # 先验证三类文件管理器动作能生成对应平台命令。
+    def test_open_directory_builds_platform_command(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch("jarvis_launcher._plat.system", return_value="Darwin"):
+                command = jarvis_launcher.build_file_manager_command(
+                    "open_directory",
+                    temp_dir,
+                )
+
+        self.assertEqual(command, ["open", temp_dir])
+
+    def test_reveal_file_builds_platform_command(self):
+        with tempfile.NamedTemporaryFile() as temp_file:
+            with patch("jarvis_launcher._plat.system", return_value="Darwin"):
+                command = jarvis_launcher.build_file_manager_command(
+                    "reveal_file",
+                    temp_file.name,
+                )
+
+        self.assertEqual(command, ["open", "-R", temp_file.name])
+
+    def test_open_file_builds_platform_command(self):
+        with tempfile.NamedTemporaryFile() as temp_file:
+            with patch("jarvis_launcher._plat.system", return_value="Linux"):
+                command = jarvis_launcher.build_file_manager_command(
+                    "open_file",
+                    temp_file.name,
+                )
+
+        self.assertEqual(command, ["xdg-open", temp_file.name])
+
+    def test_rejects_missing_path(self):
+        with self.assertRaisesRegex(ValueError, "path is required"):
+            jarvis_launcher.build_file_manager_command("open_directory", "")
+
+    def test_rejects_unknown_action(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError, "unsupported file manager action"):
+                jarvis_launcher.build_file_manager_command("delete_file", temp_dir)
+
+    def test_rejects_missing_local_path(self):
+        # 在临时目录里构造不存在的子路径，避免和真实文件撞名。
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing_path = os.path.join(temp_dir, "missing-file.txt")
+
+            with self.assertRaisesRegex(FileNotFoundError, "local path does not exist"):
+                jarvis_launcher.build_file_manager_command("open_file", missing_path)
+
+    def test_open_directory_requires_directory(self):
+        with tempfile.NamedTemporaryFile() as temp_file:
+            with self.assertRaisesRegex(NotADirectoryError, "directory path required"):
+                jarvis_launcher.build_file_manager_command(
+                    "open_directory",
+                    temp_file.name,
+                )
+
+    def test_open_file_requires_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(IsADirectoryError, "file path required"):
+                jarvis_launcher.build_file_manager_command("open_file", temp_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #9

---

## Summary of Changes

- Add native file-manager commands for `open_directory`, `reveal_file`, and `open_file`.
- Wire those commands into `browserClient.py` so assistant actions can open local folders/files without requiring a browser page.
- Add a `/file_manager` launcher endpoint plus README examples and focused unit tests.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / tooling / config change

---

## Testing Performed

- [ ] Tested on **Windows**
- [x] Tested on **macOS**
- [ ] Tested on **Linux**
- Platform tested on: macOS, local checkout
- Python version: Python 3.12

Steps to verify:

1. `python3 -m unittest discover`
2. `python3 -m py_compile jarvis_launcher.py browserClient.py tests/test_file_manager_actions.py`
3. `git diff --check`

---

## Reward Points Requested

Points requested: **100**
Justification: New feature (small) with focused unit tests.

---

## Checklist

- [x] My code follows the project's style guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] I have commented any non-obvious logic
- [x] I have updated relevant documentation (README, JARVIS_README, docstrings)
- [x] My changes do not introduce new warnings or errors
- [x] I have tested this on at least one supported platform
- [x] I have not committed secrets, API keys, or personal config files
