### PR TITLE
ci: add cross-platform packaging scaffold

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,44 @@
+name: Build packages
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  package:
+    name: Package on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Linux audio dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y portaudio19-dev
+
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Install Playwright browser
+        run: python -m playwright install chromium
+
+      - name: Build package
+        run: python scripts/build_package.py
+
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: jarvis-${{ runner.os }}
+          path: package/*.zip

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -1,0 +1,29 @@
+# Packaging JARVIS
+
+This project can be packaged as a single-file desktop launcher with PyInstaller. The package includes the launcher, browser client, visual HTML assets, web terminal HTML, and example config.
+
+## Local Build
+
+```bash
+python -m pip install -r requirements.txt
+python -m playwright install chromium
+python scripts/build_package.py
+```
+
+The build writes a platform-specific zip under `package/`, for example:
+
+```text
+package/jarvis-darwin-arm64.zip
+package/jarvis-linux-x86_64.zip
+package/jarvis-windows-amd64.zip
+```
+
+## GitHub Actions
+
+The `package.yml` workflow builds artifacts on Windows, macOS, and Linux. It installs Python dependencies, installs Chromium for Playwright, runs the packaging script, and uploads the generated zip package from each runner.
+
+## Notes
+
+- The package is unsigned. Maintainers can add code signing, notarization, or installer generation after validating the artifact layout.
+- Playwright browser installation is still required during packaging so bundled browser automation dependencies are available.
+- End users should copy `config.example.json` to `config.json` next to the executable and add their Toingg token before launching.

--- a/jarvis_launcher.spec
+++ b/jarvis_launcher.spec
@@ -1,0 +1,54 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from pathlib import Path
+
+
+ROOT = Path(SPECPATH)
+
+
+datas = [
+    (str(ROOT / "jarvis_web.html"), "."),
+    (str(ROOT / "jarvis_visual.html"), "."),
+    (str(ROOT / "browserClient.py"), "."),
+    (str(ROOT / "config.example.json"), "."),
+]
+
+
+a = Analysis(
+    ["jarvis_launcher.py"],
+    pathex=[str(ROOT)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=[
+        "playwright.sync_api",
+        "playwright_stealth",
+        "speech_recognition",
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="jarvis",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+pyaudio>=0.2.14
+numpy>=1.24
+websocket-client>=1.8
+rich>=13.7
+SpeechRecognition>=3.10
+playwright>=1.44
+playwright-stealth>=1.0
+pyinstaller>=6.7
+pyobjc-framework-Cocoa>=10.3; sys_platform == "darwin"

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Build a local distributable JARVIS package for the current platform."""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DIST = ROOT / "dist"
+PACKAGE_ROOT = ROOT / "package"
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, cwd=ROOT, check=True)
+
+
+def copy_if_exists(source: Path, target: Path) -> None:
+    if source.exists():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_dir():
+            if target.exists():
+                shutil.rmtree(target)
+            shutil.copytree(source, target)
+        else:
+            shutil.copy2(source, target)
+
+
+def build_zip() -> Path:
+    system = platform.system().lower()
+    machine = platform.machine().lower() or "unknown"
+    package_name = f"jarvis-{system}-{machine}"
+    staging = PACKAGE_ROOT / package_name
+
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+
+    executable = DIST / ("jarvis.exe" if platform.system() == "Windows" else "jarvis")
+    copy_if_exists(executable, staging / executable.name)
+    copy_if_exists(ROOT / "config.example.json", staging / "config.example.json")
+    copy_if_exists(ROOT / "README.md", staging / "README.md")
+    copy_if_exists(ROOT / "docs" / "PACKAGING.md", staging / "PACKAGING.md")
+
+    archive = shutil.make_archive(str(PACKAGE_ROOT / package_name), "zip", staging)
+    return Path(archive)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build the JARVIS executable package.")
+    parser.add_argument(
+        "--skip-pyinstaller",
+        action="store_true",
+        help="Only assemble the package from an existing dist/jarvis binary.",
+    )
+    args = parser.parse_args()
+
+    if not args.skip_pyinstaller:
+        run(["pyinstaller", "--clean", "--noconfirm", "jarvis_launcher.spec"])
+
+    archive = build_zip()
+    print(f"Built {archive.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
/claim #13

Adds a focused cross-platform packaging scaffold for JARVIS without changing launcher runtime behavior.

## Changes
- Added `requirements.txt` with runtime, browser automation, and packaging dependencies.
- Added `jarvis_launcher.spec` to bundle the launcher, browser client, HTML UI assets, and example config with PyInstaller.
- Added `scripts/build_package.py` to build a platform-specific zip package from the PyInstaller output.
- Added `.github/workflows/package.yml` to build package artifacts on Windows, macOS, and Linux.
- Added `docs/PACKAGING.md` with local and CI packaging instructions.

## Demo
https://raw.githubusercontent.com/BowenMilner/toingg-jarvis/codex-demo-artifacts-toingg-13-20260604/demo/packaging-scaffold-demo.mp4

## Validation
- `python3 -m py_compile scripts/build_package.py`
- `python3 scripts/build_package.py --help`
- `git diff --check`

PyInstaller is not installed in this local environment, so I did not run a full local binary build. The workflow added in this PR is intended to perform the real platform artifact builds in GitHub Actions.
