### PR TITLE
feat: add browser window placement options

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ python3 jarvis_launcher.py
 # Then say: "Hey Jarvis"
 ```
 
+Optional browser placement flags:
+
+```bash
+python3 jarvis_launcher.py --monitor active --window-size 1600x900 --position center
+```
+
 > 💡 No API key yet? The launcher will walk you through getting one interactively.
 
 ---
@@ -441,6 +447,9 @@ Key settings in the source files:
 | `HTTP_PORT` | `jarvis_launcher.py` | `8766` | Local server port |
 | `energy_threshold` | `jarvis_launcher.py` | `400` | Mic sensitivity (lower = more sensitive) |
 | `pause_threshold` | `jarvis_launcher.py` | `1.2` s | Silence duration before phrase ends |
+| `browser.preferred_monitor` | `config.json`, env, CLI | `active` | Preferred browser monitor (`active`, `primary`, `monitor-1`, `monitor-2`) |
+| `browser.window_size` | `config.json`, env, CLI | Default per window | Browser window size, e.g. `1600x900` |
+| `browser.position` | `config.json`, env, CLI | Default per window | Browser position (`center`, `top-left`, `top-right`, or `x=1920,y=0`) |
 | `BROWSER_ACTION_DELAY_MS` | `jarvis_web.html` | `900` ms | Delay before first browser tab opens after audio starts |
 | `MIN_BROWSER_ACTION_AUDIO_LEAD` | `jarvis_web.html` | `0.65` s | Minimum audio buffer lead before spawning Chrome |
 | `PLAYBACK_IDLE_GRACE_MS` | `jarvis_web.html` | `220` ms | Grace period after last audio chunk before marking idle |

--- a/browserClient.py
+++ b/browserClient.py
@@ -25,6 +25,12 @@ import base64
 import websocket
 from playwright.sync_api import sync_playwright, Page, Playwright
 
+from browser_window_config import (
+    BrowserWindowConfig,
+    chrome_window_args,
+    parse_browser_window_config,
+)
+
 # playwright-stealth >= 2.x uses `Stealth`; older 1.x used `stealth_sync`.
 try:
     from playwright_stealth import Stealth
@@ -95,10 +101,17 @@ STEALTH_INIT_SCRIPT = """
 
 
 class BrowserClient:
-    def __init__(self, ws_url: str, headless: bool = False, user_data_dir: str | None = None):
+    def __init__(
+        self,
+        ws_url: str,
+        headless: bool = False,
+        user_data_dir: str | None = None,
+        browser_window_config: BrowserWindowConfig | None = None,
+    ):
         self.ws_url = ws_url
         self.headless = headless
         self.user_data_dir = os.path.expanduser(user_data_dir or ".browser-profile")
+        self.browser_window_config = browser_window_config or parse_browser_window_config()
         self.ws: websocket.WebSocketApp | None = None
         self.page: Page | None = None
         self.playwright: Playwright | None = None
@@ -1242,21 +1255,17 @@ class BrowserClient:
     def run(self):
         with sync_playwright() as pw:
             self.playwright = pw
+            launch_options = build_launch_options(self.browser_window_config)
             context = pw.chromium.launch_persistent_context(
                 user_data_dir=self.user_data_dir,
                 headless=self.headless,
-                args=[
-                    "--no-sandbox",
-                    "--disable-dev-shm-usage",
-                    # NOTE: --disable-blink-features=AutomationControlled is intentionally
-                    # omitted — the flag itself is a bot signal; stealth patches handle this.
-                ],
+                args=launch_options["args"],
                 user_agent=(
                     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
                     "AppleWebKit/537.36 (KHTML, like Gecko) "
                     "Chrome/124.0.0.0 Safari/537.36"
                 ),
-                viewport={"width": 1366, "height": 768},
+                viewport=launch_options["viewport"],
                 locale="en-US",
                 timezone_id="America/New_York",
                 color_scheme="light",
@@ -1293,6 +1302,34 @@ class BrowserClient:
             log.info("Browser closed")
 
 
+def build_launch_options(config: BrowserWindowConfig):
+    width, height = config.window_size or (1366, 768)
+    args = [
+        "--no-sandbox",
+        "--disable-dev-shm-usage",
+        # NOTE: --disable-blink-features=AutomationControlled is intentionally
+        # omitted because the flag itself is a bot signal; stealth patches handle this.
+    ]
+    if config.window_size:
+        if isinstance(config.position, tuple):
+            x, y = config.position
+        else:
+            x, y = 0, 0
+        args.extend(chrome_window_args(width, height, x, y))
+    elif isinstance(config.position, tuple):
+        args.append(f"--window-position={config.position[0]},{config.position[1]}")
+
+    return {"args": args, "viewport": {"width": width, "height": height}}
+
+
+def _browser_cli_values(args):
+    return {
+        "preferred_monitor": args.monitor,
+        "window_size": args.window_size,
+        "position": args.position,
+    }
+
+
 def main():
     parser = argparse.ArgumentParser(description="Toingg browser automation client")
     parser.add_argument(
@@ -1310,9 +1347,27 @@ def main():
         default=".browser-profile",
         help="Persistent browser profile directory for cookies and login sessions",
     )
+    parser.add_argument(
+        "--monitor",
+        help="Preferred monitor for browser windows: active, primary, monitor-1, monitor-2",
+    )
+    parser.add_argument(
+        "--window-size",
+        dest="window_size",
+        help="Browser window size, for example 1600x900",
+    )
+    parser.add_argument(
+        "--position",
+        help="Browser window position: center, top-left, top-right, or x=1920,y=0",
+    )
     args = parser.parse_args()
 
-    client = BrowserClient(ws_url=args.url, headless=args.headless, user_data_dir=args.user_data_dir)
+    client = BrowserClient(
+        ws_url=args.url,
+        headless=args.headless,
+        user_data_dir=args.user_data_dir,
+        browser_window_config=parse_browser_window_config(cli_values=_browser_cli_values(args)),
+    )
     try:
         client.run()
     except KeyboardInterrupt:

--- a/browser_window_config.py
+++ b/browser_window_config.py
@@ -1,0 +1,139 @@
+import json
+import os
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BrowserWindowConfig:
+    preferred_monitor: str = "active"
+    window_size: tuple[int, int] | None = None
+    position: str | tuple[int, int] | None = None
+
+
+def parse_window_size(value):
+    if value is None or value == "":
+        return None
+    if isinstance(value, dict):
+        width = value.get("width")
+        height = value.get("height")
+    elif isinstance(value, (list, tuple)) and len(value) == 2:
+        width, height = value
+    else:
+        match = re.fullmatch(r"\s*(\d+)\s*[xX,]\s*(\d+)\s*", str(value))
+        if not match:
+            raise ValueError(f"Invalid browser window size: {value!r}")
+        width, height = match.groups()
+
+    width, height = int(width), int(height)
+    if width <= 0 or height <= 0:
+        raise ValueError("Browser window width and height must be positive")
+    return width, height
+
+
+def parse_window_position(value):
+    if value is None or value == "":
+        return None
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        return int(value[0]), int(value[1])
+
+    text = str(value).strip().lower()
+    if text in {"center", "top-left", "top-right"}:
+        return text
+
+    match = re.fullmatch(r"x\s*=\s*(-?\d+)\s*,\s*y\s*=\s*(-?\d+)", text)
+    if match:
+        return int(match.group(1)), int(match.group(2))
+
+    raise ValueError(f"Invalid browser window position: {value!r}")
+
+
+def parse_browser_window_config(config_data=None, environ=None, cli_values=None, config_path=None):
+    environ = environ if environ is not None else os.environ
+    cli_values = cli_values or {}
+    config_data = config_data if config_data is not None else _load_config_file(config_path)
+    browser_data = config_data.get("browser", {}) if isinstance(config_data, dict) else {}
+
+    preferred_monitor = _first_non_empty(
+        cli_values.get("preferred_monitor") or cli_values.get("monitor"),
+        environ.get("JARVIS_BROWSER_MONITOR"),
+        browser_data.get("preferred_monitor") or browser_data.get("monitor"),
+        "active",
+    )
+    window_size = _first_non_empty(
+        cli_values.get("window_size"),
+        environ.get("JARVIS_BROWSER_WINDOW_SIZE"),
+        browser_data.get("window_size"),
+    )
+    position = _first_non_empty(
+        cli_values.get("position"),
+        environ.get("JARVIS_BROWSER_POSITION"),
+        browser_data.get("position"),
+    )
+
+    return BrowserWindowConfig(
+        preferred_monitor=str(preferred_monitor).strip().lower(),
+        window_size=parse_window_size(window_size),
+        position=parse_window_position(position),
+    )
+
+
+def resolve_window_geometry(config, default_size, default_position, screen_bounds):
+    width, height = config.window_size or default_size
+    default_x, default_y = default_position
+
+    if isinstance(config.position, tuple):
+        x, y = config.position
+    elif config.position == "center":
+        sx, sy, sw, sh = screen_bounds
+        x = sx + max(0, (sw - width) // 2)
+        y = sy + max(0, (sh - height) // 2)
+    elif config.position == "top-left":
+        sx, sy, _, _ = screen_bounds
+        x, y = sx, sy
+    elif config.position == "top-right":
+        sx, sy, sw, _ = screen_bounds
+        x = sx + max(0, sw - width)
+        y = sy
+    else:
+        x, y = default_x, default_y
+
+    return int(width), int(height), int(x), int(y)
+
+
+def choose_screen_bounds(preferred_monitor, screens, active_screen, fallback_screen):
+    monitor = str(preferred_monitor or "active").strip().lower()
+    screens = list(screens or [])
+
+    if monitor == "active":
+        return active_screen or (screens[0] if screens else fallback_screen)
+    if monitor == "primary":
+        return screens[0] if screens else active_screen or fallback_screen
+
+    match = re.fullmatch(r"monitor-(\d+)", monitor)
+    if match:
+        index = int(match.group(1)) - 1
+        if 0 <= index < len(screens):
+            return screens[index]
+
+    return active_screen or (screens[0] if screens else fallback_screen)
+
+
+def chrome_window_args(width, height, x, y):
+    return [f"--window-size={int(width)},{int(height)}", f"--window-position={int(x)},{int(y)}"]
+
+
+def _first_non_empty(*values):
+    for value in values:
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _load_config_file(config_path):
+    path = config_path or os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.json")
+    try:
+        with open(path, "r", encoding="utf-8") as fp:
+            return json.load(fp)
+    except FileNotFoundError:
+        return {}

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,13 @@
 {
   "WS_URL": "wss://prepodapi.toingg.com/api/v3/media/streaming",
   "TOKEN":  "your-token-here",
-  "CAMP_ID": "your-campaign-id-here"
+  "CAMP_ID": "your-campaign-id-here",
+  "browser": {
+    "preferred_monitor": "active",
+    "window_size": {
+      "width": 1600,
+      "height": 900
+    },
+    "position": "center"
+  }
 }

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -760,7 +760,7 @@ def open_jarvis_web_bg():
                 # it silently blocks WebSocket connections on Chrome 120+
             ])
         _web_proc = subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        print(f"  [web] ✅ opened ({win_w}×{win_h} @ {wx},{wy}) — click window once to activate audio")
+        print(f"  [web] opened ({win_w}x{win_h} @ {wx},{wy}) - click window once to activate audio")
     else:
         webbrowser.open(url)
 

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -12,12 +12,19 @@ Requirements:
     pip install sounddevice numpy speechrecognition
 """
 
+import argparse
 import os, sys, time, threading, subprocess, tempfile, json, webbrowser
 import uuid
 import ctypes, ctypes.wintypes
 import platform as _plat
 from datetime import datetime, timedelta, timezone
 
+from browser_window_config import (
+    choose_screen_bounds,
+    chrome_window_args,
+    parse_browser_window_config,
+    resolve_window_geometry,
+)
 from native_file_manager import NativeFileActionError, handle_file_action_payload
 
 # ── CONFIG ────────────────────────────────────────────────────────────────────
@@ -43,6 +50,8 @@ _url_slot      = 0
 _url_slot_wins = {}
 _url_slot_modes = {}
 _slot_profiles = {}
+BROWSER_WINDOW_CONFIG = parse_browser_window_config()
+BROWSER_CLIENT_ARGS = []
 
 # ── APP REGISTRY ──────────────────────────────────────────────────────────────
 _IS_MAC = _plat.system() == "Darwin"
@@ -267,7 +276,126 @@ def _ensure_profile(slot):
         _slot_profiles[slot] = d
     return _slot_profiles[slot]
 
-def _slot_pos(slot):
+def _available_screen_bounds():
+    plat = _plat.system()
+    if plat == "Windows":
+        try:
+            monitors = []
+            user32 = ctypes.windll.user32
+
+            class _RECT(ctypes.Structure):
+                _fields_ = [
+                    ("left", ctypes.c_long), ("top", ctypes.c_long),
+                    ("right", ctypes.c_long), ("bottom", ctypes.c_long),
+                ]
+
+            class _MONITORINFO(ctypes.Structure):
+                _fields_ = [
+                    ("cbSize", ctypes.c_ulong),
+                    ("rcMonitor", _RECT),
+                    ("rcWork", _RECT),
+                    ("dwFlags", ctypes.c_ulong),
+                ]
+
+            def _callback(hmonitor, hdc, lprect, lparam):
+                info = _MONITORINFO()
+                info.cbSize = ctypes.sizeof(_MONITORINFO)
+                if user32.GetMonitorInfoW(hmonitor, ctypes.byref(info)):
+                    r = info.rcWork
+                    monitors.append((r.left, r.top, r.right - r.left, r.bottom - r.top))
+                return 1
+
+            monitor_enum_proc = ctypes.WINFUNCTYPE(
+                ctypes.c_int,
+                ctypes.c_ulong,
+                ctypes.c_ulong,
+                ctypes.POINTER(_RECT),
+                ctypes.c_double,
+            )
+            user32.EnumDisplayMonitors(0, 0, monitor_enum_proc(_callback), 0)
+            return monitors
+        except Exception:
+            return []
+
+    if plat == "Darwin":
+        try:
+            from AppKit import NSScreen
+
+            screens = list(NSScreen.screens())
+            if not screens:
+                return []
+            max_y = max(s.frame().origin.y + s.frame().size.height for s in screens)
+            bounds = []
+            for screen in screens:
+                frame = screen.frame()
+                sx, sy = frame.origin.x, frame.origin.y
+                sw, sh = frame.size.width, frame.size.height
+                bounds.append((int(sx), int(max_y - (sy + sh)), int(sw), int(sh)))
+            return bounds
+        except Exception:
+            return []
+
+    try:
+        import re
+        out = subprocess.check_output(["xrandr", "--listmonitors"], text=True, stderr=subprocess.DEVNULL)
+        bounds = []
+        for line in out.splitlines()[1:]:
+            match = re.search(r"(\d+)/\d+x(\d+)/\d+\+(-?\d+)\+(-?\d+)", line)
+            if match:
+                width, height, x, y = [int(part) for part in match.groups()]
+                bounds.append((x, y, width, height))
+        return bounds
+    except Exception:
+        return []
+
+def _screen_bounds_for_window_config():
+    active = get_active_screen_bounds()
+    sw, sh = get_screen_size()
+    fallback = (0, 0, sw, sh)
+    return choose_screen_bounds(
+        BROWSER_WINDOW_CONFIG.preferred_monitor,
+        _available_screen_bounds(),
+        active,
+        fallback,
+    )
+
+def _resolve_configured_geometry(default_size, default_position):
+    return resolve_window_geometry(
+        BROWSER_WINDOW_CONFIG,
+        default_size=default_size,
+        default_position=default_position,
+        screen_bounds=_screen_bounds_for_window_config(),
+    )
+
+def _parse_browser_window_cli(argv):
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--monitor", dest="preferred_monitor")
+    parser.add_argument("--window-size", dest="window_size")
+    parser.add_argument("--position")
+    args, _ = parser.parse_known_args(argv)
+    return {key: value for key, value in vars(args).items() if value}
+
+def _browser_client_args_from_config(config):
+    args = []
+    if config.preferred_monitor:
+        args.extend(["--monitor", config.preferred_monitor])
+    if config.window_size:
+        args.extend(["--window-size", f"{config.window_size[0]}x{config.window_size[1]}"])
+    if config.position:
+        if isinstance(config.position, tuple):
+            position = f"x={config.position[0]},y={config.position[1]}"
+        else:
+            position = config.position
+        args.extend(["--position", position])
+    return args
+
+def configure_browser_windows(argv=None):
+    global BROWSER_WINDOW_CONFIG, BROWSER_CLIENT_ARGS
+    BROWSER_WINDOW_CONFIG = parse_browser_window_config(cli_values=_parse_browser_window_cli(argv or []))
+    BROWSER_CLIENT_ARGS = _browser_client_args_from_config(BROWSER_WINDOW_CONFIG)
+    return BROWSER_WINDOW_CONFIG
+
+def _slot_pos(slot, win_w=URL_WIN_W, win_h=URL_WIN_H):
     """
     2×2 grid inset from screen edges:
       slot 0 = top-left    slot 1 = top-right
@@ -282,10 +410,10 @@ def _slot_pos(slot):
     p   = _PADDING
     col = slot % 2
     row = slot // 2
-    x   = sx + p + col * (URL_WIN_W + p)
-    y   = sy + p + row * (URL_WIN_H + p)
-    x   = min(x, sx + sw - URL_WIN_W - p)
-    y   = min(y, sy + sh - URL_WIN_H - p)
+    x   = sx + p + col * (win_w + p)
+    y   = sy + p + row * (win_h + p)
+    x   = min(x, sx + sw - win_w - p)
+    y   = min(y, sy + sh - win_h - p)
     return x, y
 
 def _is_desktop_preview_tab(tab):
@@ -327,8 +455,9 @@ def open_url_in_slot(url, slot, tab=None):
     if desktop_preview:
         win_w, win_h, x, y = _desktop_preview_geometry()
     else:
-        win_w, win_h = URL_WIN_W, URL_WIN_H
-        x, y = _slot_pos(slot)
+        default_w, default_h = BROWSER_WINDOW_CONFIG.window_size or (URL_WIN_W, URL_WIN_H)
+        x, y = _slot_pos(slot, default_w, default_h)
+        win_w, win_h, x, y = _resolve_configured_geometry((URL_WIN_W, URL_WIN_H), (x, y))
     profile = _ensure_profile(slot)
 
     old = _url_slot_wins.get(slot)
@@ -345,8 +474,7 @@ def open_url_in_slot(url, slot, tab=None):
             f"--user-data-dir={profile}",
             "--no-first-run",
             "--no-default-browser-check",
-            f"--window-size={win_w},{win_h}",
-            f"--window-position={x},{y}",
+            *chrome_window_args(win_w, win_h, x, y),
             url,
         ]
         # Mac-specific: suppress non-essential background services
@@ -555,7 +683,7 @@ def start_browser_client():
         print("  [browser] ⚠  browserClient.py not found"); return
 
     try:
-        _browser_client_proc = subprocess.Popen([sys.executable, BROWSER_CLIENT], cwd=_DIR)
+        _browser_client_proc = subprocess.Popen([sys.executable, BROWSER_CLIENT, *BROWSER_CLIENT_ARGS], cwd=_DIR)
         print("  [browser] ✅ browserClient.py started")
     except Exception as e:
         print(f"  [browser] ⚠  Failed to start browserClient.py: {e}")
@@ -568,8 +696,10 @@ def open_jarvis_visual():
 
     url     = f"http://localhost:{HTTP_PORT}/visual"
     chrome  = find_chrome()
-    win_w, win_h = 420, 520
-    vx, vy = top_center_near_active_window(win_w)
+    default_size = (420, 520)
+    default_w = BROWSER_WINDOW_CONFIG.window_size[0] if BROWSER_WINDOW_CONFIG.window_size else default_size[0]
+    vx, vy = top_center_near_active_window(default_w)
+    win_w, win_h, vx, vy = _resolve_configured_geometry(default_size, (vx, vy))
     profile = os.path.join(tempfile.gettempdir(), "jarvis_chrome_visual")
     os.makedirs(profile, exist_ok=True)
     if chrome:
@@ -580,8 +710,7 @@ def open_jarvis_visual():
             "--no-first-run",
             "--no-default-browser-check",
             "--autoplay-policy=no-user-gesture-required",
-            f"--window-size={win_w},{win_h}",
-            f"--window-position={vx},{vy}",
+            *chrome_window_args(win_w, win_h, vx, vy),
         ]
         if _IS_MAC:
             args.extend([
@@ -604,8 +733,10 @@ def open_jarvis_web_bg():
 
     url     = f"http://localhost:{HTTP_PORT}/"
     chrome  = find_chrome()
-    win_w, win_h = 700, 420
-    wx, wy = top_right_near_active_window(win_w)
+    default_size = (700, 420)
+    default_w = BROWSER_WINDOW_CONFIG.window_size[0] if BROWSER_WINDOW_CONFIG.window_size else default_size[0]
+    wx, wy = top_right_near_active_window(default_w)
+    win_w, win_h, wx, wy = _resolve_configured_geometry(default_size, (wx, wy))
 
     profile = os.path.join(tempfile.gettempdir(), "jarvis_chrome_web")
     os.makedirs(profile, exist_ok=True)
@@ -618,8 +749,7 @@ def open_jarvis_web_bg():
             "--no-first-run",
             "--no-default-browser-check",
             "--autoplay-policy=no-user-gesture-required",
-            f"--window-size={win_w},{win_h}",
-            f"--window-position={wx},{wy}",
+            *chrome_window_args(win_w, win_h, wx, wy),
         ]
         if _IS_MAC:
             args.extend([
@@ -1207,6 +1337,7 @@ def check_api_key():
 
 # ── MAIN ──────────────────────────────────────────────────────────────────────
 def main():
+    configure_browser_windows(sys.argv[1:])
     print("""
   ╔══════════════════════════════════════════╗
   ║   W E E S T R E A M  //  J A R V I S    ║

--- a/test_browser_window_config.py
+++ b/test_browser_window_config.py
@@ -1,0 +1,127 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import jarvis_launcher
+sys.modules.setdefault("websocket", types.SimpleNamespace(WebSocketApp=object))
+sys.modules.setdefault("playwright", types.ModuleType("playwright"))
+playwright_sync_api = types.ModuleType("playwright.sync_api")
+playwright_sync_api.Page = object
+playwright_sync_api.Playwright = object
+playwright_sync_api.sync_playwright = lambda: None
+sys.modules.setdefault("playwright.sync_api", playwright_sync_api)
+import browserClient
+from browser_window_config import (
+    BrowserWindowConfig,
+    chrome_window_args,
+    choose_screen_bounds,
+    parse_browser_window_config,
+    parse_window_position,
+    parse_window_size,
+    resolve_window_geometry,
+)
+
+
+class BrowserWindowConfigTests(unittest.TestCase):
+    def test_parse_window_size_accepts_common_terminal_format(self):
+        self.assertEqual(parse_window_size("1600x900"), (1600, 900))
+        self.assertEqual(parse_window_size(" 1024 X 768 "), (1024, 768))
+
+    def test_parse_window_position_accepts_named_and_coordinate_values(self):
+        self.assertEqual(parse_window_position("center"), "center")
+        self.assertEqual(parse_window_position("top-left"), "top-left")
+        self.assertEqual(parse_window_position("x=1920,y=0"), (1920, 0))
+
+    def test_cli_values_override_environment_and_config_file_values(self):
+        config = parse_browser_window_config(
+            config_data={
+                "browser": {
+                    "preferred_monitor": "primary",
+                    "window_size": {"width": 1200, "height": 800},
+                    "position": "top-left",
+                }
+            },
+            environ={
+                "JARVIS_BROWSER_MONITOR": "monitor-2",
+                "JARVIS_BROWSER_WINDOW_SIZE": "1400x850",
+                "JARVIS_BROWSER_POSITION": "center",
+            },
+            cli_values={
+                "preferred_monitor": "active",
+                "window_size": "1600x900",
+                "position": "x=1920,y=0",
+            },
+        )
+
+        self.assertEqual(config.preferred_monitor, "active")
+        self.assertEqual(config.window_size, (1600, 900))
+        self.assertEqual(config.position, (1920, 0))
+
+    def test_resolve_window_geometry_uses_configured_size_and_position(self):
+        config = BrowserWindowConfig(
+            preferred_monitor="active",
+            window_size=(1600, 900),
+            position="center",
+        )
+
+        self.assertEqual(
+            resolve_window_geometry(
+                config,
+                default_size=(700, 420),
+                default_position=(100, 20),
+                screen_bounds=(1920, 0, 1920, 1080),
+            ),
+            (1600, 900, 2080, 90),
+        )
+
+    def test_chrome_window_args_formats_size_and_position_switches(self):
+        self.assertEqual(
+            chrome_window_args(1600, 900, 1920, 0),
+            ["--window-size=1600,900", "--window-position=1920,0"],
+        )
+
+    def test_choose_screen_bounds_supports_active_primary_and_numbered_monitors(self):
+        screens = [(0, 0, 1280, 720), (1280, 0, 1920, 1080)]
+        active = (1280, 0, 1920, 1080)
+        fallback = (0, 0, 1920, 1080)
+
+        self.assertEqual(choose_screen_bounds("active", screens, active, fallback), active)
+        self.assertEqual(choose_screen_bounds("primary", screens, active, fallback), screens[0])
+        self.assertEqual(choose_screen_bounds("monitor-2", screens, active, fallback), screens[1])
+        self.assertEqual(choose_screen_bounds("monitor-9", screens, active, fallback), active)
+
+    def test_launcher_applies_configured_web_window_geometry(self):
+        jarvis_launcher.configure_browser_windows(
+            ["--window-size", "900x500", "--position", "center"]
+        )
+        jarvis_launcher._web_proc = None
+
+        with patch.object(jarvis_launcher, "find_chrome", return_value="chrome"), \
+                patch.object(jarvis_launcher, "get_active_screen_bounds", return_value=(0, 0, 1000, 800)), \
+                patch.object(jarvis_launcher.subprocess, "Popen") as popen:
+            popen.return_value.poll.return_value = None
+
+            jarvis_launcher.open_jarvis_web_bg()
+
+        chrome_args = popen.call_args.args[0]
+        self.assertIn("--window-size=900,500", chrome_args)
+        self.assertIn("--window-position=50,150", chrome_args)
+        jarvis_launcher.configure_browser_windows([])
+
+    def test_browser_client_launch_options_include_window_config(self):
+        config = BrowserWindowConfig(
+            preferred_monitor="active",
+            window_size=(1440, 900),
+            position=(20, 40),
+        )
+
+        options = browserClient.build_launch_options(config)
+
+        self.assertEqual(options["viewport"], {"width": 1440, "height": 900})
+        self.assertIn("--window-size=1440,900", options["args"])
+        self.assertIn("--window-position=20,40", options["args"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses #8.

## Summary
- Add shared browser window configuration parsing for config.json, environment variables, and CLI flags.
- Apply configured browser size/position/monitor selection to launcher Chrome windows and pass the same options to browserClient.py.
- Add Playwright launch option support for configured viewport/window args.
- Document the new options in README.md and config.example.json.

## Usage
```bash
python3 jarvis_launcher.py --monitor active --window-size 1600x900 --position center
```

Environment equivalents:
- JARVIS_BROWSER_MONITOR
- JARVIS_BROWSER_WINDOW_SIZE
- JARVIS_BROWSER_POSITION

## Validation
```bash
python -m pytest -q
# 17 passed

python -m py_compile browser_window_config.py browserClient.py jarvis_launcher.py test_browser_window_config.py
# passed

git diff --check
# no whitespace errors
```