### PR TITLE
feat: Cross-platform packaging (PyInstaller + CI/CD) + bug fixes #13 #15 #17 #21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,170 @@
+name: Build & Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g. v2.1.0)"
+        required: true
+        default: "v2.1.0"
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install pyaudio numpy websocket-client rich SpeechRecognition playwright playwright-stealth
+
+      - name: Build with PyInstaller
+        run: pyinstaller jarvis.spec --clean --noconfirm
+
+      - name: Package as portable ZIP
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}"
+          if ($version -eq "") { $version = "${{ inputs.version }}" }
+          $version = $version -replace '^v', ''
+          Compress-Archive -Path dist\JARVIS\* -DestinationPath "JARVIS-$version-win64-portable.zip"
+
+      - name: Upload portable ZIP
+        uses: actions/upload-artifact@v4
+        with:
+          name: JARVIS-win64-portable
+          path: JARVIS-*-win64-portable.zip
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install system dependencies
+        run: brew install portaudio
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install pyaudio numpy websocket-client rich SpeechRecognition playwright playwright-stealth
+
+      - name: Build with PyInstaller
+        run: pyinstaller jarvis.spec --clean --noconfirm
+
+      - name: Create DMG
+        run: |
+          VERSION="${{ github.ref_name }}"
+          if [ -z "$VERSION" ]; then VERSION="${{ inputs.version }}"; fi
+          VERSION=$(echo "$VERSION" | sed 's/^v//')
+          mkdir -p dmg_staging
+          cp -R dist/JARVIS/* dmg_staging/
+          cp JARVIS.command dmg_staging/
+          cp setup_mac.sh dmg_staging/
+          chmod +x dmg_staging/JARVIS dmg_staging/JARVIS.command dmg_staging/setup_mac.sh
+          hdiutil create -volname "JARVIS" -srcfolder dmg_staging -ov -format UDZO "JARVIS-${VERSION}-macos.dmg"
+
+      - name: Upload DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: JARVIS-macos-dmg
+          path: JARVIS-*-macos.dmg
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev python3-pyaudio python3-dev binutils
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install pyaudio numpy websocket-client rich SpeechRecognition playwright playwright-stealth
+
+      - name: Build with PyInstaller
+        run: pyinstaller jarvis.spec --clean --noconfirm
+
+      - name: Package as portable tarball
+        run: |
+          VERSION="${{ github.ref_name }}"
+          if [ -z "$VERSION" ]; then VERSION="${{ inputs.version }}"; fi
+          VERSION=$(echo "$VERSION" | sed 's/^v//')
+          cd dist/JARVIS
+          tar czf "../../JARVIS-${VERSION}-linux-x64.tar.gz" *
+
+      - name: Upload portable tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: JARVIS-linux-portable
+          path: JARVIS-*-linux-x64.tar.gz
+
+  create-release:
+    needs: [build-windows, build-macos, build-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Flatten artifacts
+        run: |
+          find artifacts -type f \( -name "*.zip" -o -name "*.dmg" -o -name "*.tar.gz" \) \
+            -exec cp {} ./ \;
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name || inputs.version }}
+          name: "JARVIS ${{ github.ref_name || inputs.version }}"
+          body: |
+            ## J.A.R.V.I.S ${{ github.ref_name || inputs.version }}
+
+            Cross-platform voice AI terminal powered by Toingg.
+
+            ### Download
+            - **Windows**: `JARVIS-*.zip` (extract and run `JARVIS.exe`)
+            - **macOS**: `JARVIS-*.dmg` (mount and drag to Applications)
+            - **Linux**: `JARVIS-*.tar.gz` (extract and run `./JARVIS`)
+
+            ### Requirements
+            - Microphone and speakers/headphones
+            - Google Chrome, Chromium, or Edge
+            - Toingg API key (free from prepodapp.toingg.com)
+
+            See [README.md](https://github.com/PG-AGI/toingg-jarvis#readme) for full setup instructions.
+          files: |
+            *.zip
+            *.dmg
+            *.tar.gz
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/browserClient.py
+++ b/browserClient.py
@@ -1182,7 +1182,7 @@ class BrowserClient:
     def _on_message(self, ws, raw: str):
         try:
             msg = json.loads(raw)
-            print("Received: ", msg)
+            log.debug("Received: %s", msg)
         except json.JSONDecodeError:
             return
 

--- a/jarvis.spec
+++ b/jarvis.spec
@@ -1,0 +1,112 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller spec for J.A.R.V.I.S – cross-platform packaging.
+
+Build:
+    pip install pyinstaller
+    pyinstaller jarvis.spec --clean
+
+Output:
+    dist/JARVIS/  (directory)         → run `./JARVIS` or `JARVIS.exe`
+    dist/JARVIS.exe --onedir single   (add --onefile for a single binary)
+"""
+
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(SPECPATH)
+
+block_cipher = None
+
+DATA_FILES = [
+    (str(ROOT / "jarvis_web.html"), "."),
+    (str(ROOT / "jarvis_visual.html"), "."),
+    (str(ROOT / "config.example.json"), "."),
+    (str(ROOT / "REWARD_SYSTEM.md"), "."),
+    (str(ROOT / "CONTRIBUTING.md"), "."),
+    (str(ROOT / "CODE_OF_CONDUCT.md"), "."),
+    (str(ROOT / "LICENSE"), "."),
+    (str(ROOT / "JARVIS.bat"), "."),
+    (str(ROOT / "JARVIS.command"), "."),
+    (str(ROOT / "setup_mac.sh"), "."),
+    (str(ROOT / "NATIVE_FILE_MANAGER.md"), "."),
+    (str(ROOT / "JARVIS_README.md"), "."),
+    (str(ROOT / "README.md"), "."),
+]
+
+HIDDEN_IMPORTS = [
+    "sounddevice",
+    "numpy",
+    "speech_recognition",
+    "websocket",
+    "playwright",
+    "playwright_stealth",
+    "rich",
+    "http.server",
+    "ctypes",
+    "json",
+    "threading",
+    "uuid",
+    "webbrowser",
+]
+
+EXCLUDES = [
+    "tkinter",
+    "test",
+    "unittest",
+    "setuptools",
+    "pip",
+]
+
+EXE_NAME = "JARVIS" if sys.platform != "win32" else "JARVIS.exe"
+
+a = Analysis(
+    [str(ROOT / "jarvis_launcher.py")],
+    pathex=[str(ROOT)],
+    binaries=[],
+    datas=DATA_FILES,
+    hiddenimports=HIDDEN_IMPORTS,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=EXCLUDES,
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="JARVIS",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="JARVIS",
+)

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -895,7 +895,7 @@ def find_running_pid(exe_name):
     try:
         out = subprocess.check_output(
             ["tasklist", "/FI", f"IMAGENAME eq {exe_name}", "/FO", "CSV", "/NH"],
-            shell=True, stderr=subprocess.DEVNULL
+            shell=False, stderr=subprocess.DEVNULL
         ).decode(errors="ignore")
         for line in out.strip().splitlines():
             parts = line.strip('"').split('","')
@@ -1073,7 +1073,10 @@ def voice_listener():
     while True:
         if stop_capture.is_set():
             print("  [voice] ⏸  Mic paused. Press Enter to resume...")
-            input()
+            try:
+                input()
+            except (EOFError, KeyboardInterrupt):
+                pass
             stop_capture.clear()
             print("  [voice] ▶  Resumed.\n")
         try:


### PR DESCRIPTION
## Summary

Implements cross-platform packaging ( bounty - #13) and fixes 3 bugs (#15, #17, #21).

### Packaging (#13 - $5 bounty)
- **jarvis.spec**: PyInstaller build spec bundling all data files (HTML, config template, shell scripts, docs) with proper hidden imports for all runtime dependencies
- **.github/workflows/release.yml**: Automated CI/CD pipeline building Windows (.zip), macOS (.dmg), and Linux (.tar.gz) artifacts on every * tag

### Bug Fixes
- **#15**: Replaced unconditional print('Received: ', msg) with log.debug('Received: %s', msg) in rowserClient.py - stops WebSocket message leak to stdout
- **#17**: Changed shell=True to shell=False in ind_running_pid - tasklist filter flags were silently dropped with list args + shell=True on Windows
- **#21**: Wrapped input() in oice_listener with 	ry/except (EOFError, KeyboardInterrupt): pass - prevents crash when launched without terminal (double-click on macOS/Win)

The packaging workflow triggers on git tag pushes (*) or manual workflow_dispatch. Builds PyInstaller on all 3 platforms with platform-specific dependencies (portaudio, etc.) and creates a GitHub Release with all artifacts attached.