### PR TITLE
Add scoped Pipecat Gemini backend

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,7 @@
 {
   "WS_URL": "wss://prepodapi.toingg.com/api/v3/media/streaming",
   "TOKEN":  "your-token-here",
-  "CAMP_ID": "your-campaign-id-here"
+  "CAMP_ID": "your-campaign-id-here",
+  "BACKEND": "toingg",
+  "GEMINI_API_KEY": "your-gemini-key-here"
 }

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -466,6 +466,27 @@ def create_scheduled_action(payload, now=None):
     print(f"  [schedule] queued {item['id']} for {item['scheduled_for']}")
     return item
 
+def create_playwright_action(payload, now=None):
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be a JSON object")
+    action = str(payload.get("action") or "").strip().lower()
+    if not action:
+        raise ValueError("action is required")
+    params = payload.get("params") or {}
+    if isinstance(params, str):
+        params = json.loads(params) if params.strip() else {}
+    if not isinstance(params, dict):
+        raise ValueError("params must be a JSON object")
+    scheduled_type = "open_url" if action == "navigate" else action
+    return create_scheduled_action(
+        {
+            "name": f"playwright: {action}",
+            "trigger": {"delay_seconds": 0},
+            "actions": [{"type": scheduled_type, **params}],
+        },
+        now=now,
+    )
+
 def list_scheduled_actions():
     with _scheduled_actions_lock:
         return sorted(_scheduled_actions.values(), key=lambda item: item["scheduled_for"])
@@ -803,6 +824,27 @@ def start_http_server():
                     self.wfile.write(json.dumps({"ok": True, "item": item}).encode())
                 except Exception as e:
                     print(f"  [schedule] schedule_action error: {e}")
+                    self.send_response(400)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"ok": False, "error": str(e)}).encode())
+            elif self.path == "/playwright_action":
+                try:
+                    payload = json.loads(body) if body else {}
+                    item = create_playwright_action(payload)
+                    self.send_response(201)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"ok": True, "item": item}).encode())
+                except Exception as e:
+                    print(f"  [schedule] playwright_action error: {e}")
+                    self.send_response(400)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"ok": False, "error": str(e)}).encode())
             elif self.path == "/file_action":
                 try:
                     payload = json.loads(body) if body else {}
@@ -1028,6 +1070,9 @@ def full_launch(source):
     print(f"\n  🚀  [{source}] JARVIS ACTIVATED\n")
 
     def sequence():
+        if _is_pipecat_backend():
+            print("  [pipecat] Launching Gemini backend...")
+            start_pipecat_backend()
         print("  [1/3] Browser automation client...")
         start_browser_client()
         print("  [2/3] JARVIS Visual window...")
@@ -1204,6 +1249,45 @@ def check_api_key():
 
         else:
             print("  ⚠   Invalid choice. Enter 1, 2, 3, Q, or paste your API key.\n", flush=True)
+
+# ── PIPECAT GEMINI BACKEND ───────────────────────────────────────────────────
+PIPECAT_GEMINI_SCRIPT = os.path.join(_DIR, "pipecat_gemini.py")
+_pipecat_proc = None
+
+def _is_pipecat_backend():
+    """Check if config.json requests the pipecat_gemini backend."""
+    try:
+        cfg_path = os.path.join(_DIR, "config.json")
+        with open(cfg_path, "r") as f:
+            cfg = json.load(f)
+        backend = str(cfg.get("BACKEND", "")).strip().lower()
+        if backend == "pipecat_gemini":
+            if "GEMINI_API_KEY" in os.environ:
+                return True
+            api_key = cfg.get("GEMINI_API_KEY", "").strip()
+            if api_key and api_key not in ("your-gemini-key-here", ""):
+                return True
+    except Exception:
+        pass
+    return False
+
+def start_pipecat_backend():
+    """Start pipecat_gemini.py as alternative backend."""
+    global _pipecat_proc
+    if _pipecat_proc and _pipecat_proc.poll() is None:
+        print("  [pipecat] already running"); return
+    if not os.path.exists(PIPECAT_GEMINI_SCRIPT):
+        print("  [pipecat] \u26a0  pipecat_gemini.py not found"); return
+    try:
+        _pipecat_proc = subprocess.Popen(
+            [sys.executable, PIPECAT_GEMINI_SCRIPT],
+            cwd=_DIR,
+            stdout=None,
+            stderr=None,
+        )
+        print("  [pipecat] \u2705 Gemini backend started")
+    except Exception as e:
+        print(f"  [pipecat] \u26a0  Failed: {e}")
 
 # ── MAIN ──────────────────────────────────────────────────────────────────────
 def main():

--- a/jarvis_web.html
+++ b/jarvis_web.html
@@ -1611,9 +1611,15 @@ async function loadConfig() {
   const res = await fetch("config.json");
   if (!res.ok) throw new Error(`config.json not found (${res.status})`);
   const cfg = await res.json();
-  WS_URL  = cfg.WS_URL  || "";
   TOKEN   = cfg.TOKEN   || "";
   CAMP_ID = cfg.CAMP_ID || "";
+  const backend = (cfg.BACKEND || "toingg").toLowerCase();
+  if (backend === "pipecat_gemini") {
+    WS_URL = "ws://localhost:8767";
+    logChat("sys", "\u25c8 PIPECAT/GEMINI BACKEND");
+  } else {
+    WS_URL = cfg.WS_URL || "";
+  }
 }
 
 async function boot() {

--- a/pipecat_gemini.py
+++ b/pipecat_gemini.py
@@ -1,0 +1,395 @@
+"""
+PIPECAT / GEMINI BACKEND  — J.A.R.V.I.S alternative AI pipeline
+===============================================================
+
+Usage:
+    set BACKEND=pipecat_gemini in config.json, then launch jarvis_launcher.py
+
+Requirements:
+    pip install pipecat-ai[google] websockets
+
+The jarvis_launcher auto-detects BACKEND=pipecat_gemini and spawns this
+module instead of the Toingg WebSocket flow.  This module runs a local
+WebSocket server that jarvis_web.html connects to.
+
+Supports:
+  - Real-time voice via Gemini Multimodal Live
+  - Tool calling (open_browser, close_tabs, file_action, playwright)
+  - Backend switching via config.json
+"""
+
+import asyncio
+import base64
+import json
+import os
+import signal
+import struct
+import sys
+import threading
+import time
+from urllib.parse import urlencode
+
+import requests
+import websockets
+from loguru import logger
+
+# ── Pipecat imports ─────────────────────────────────────────────────────────
+try:
+    from pipecat.adapters.schemas.function_schema import FunctionSchema
+    from pipecat.adapters.schemas.tools_schema import ToolsSchema
+    from pipecat.audio.vad.silero import SileroVADAnalyzer
+    from pipecat.frames.frames import InputAudioRawFrame, InputTextRawFrame, InterruptionFrame
+    from pipecat.pipeline.pipeline import Pipeline
+    from pipecat.pipeline.runner import PipelineRunner
+    from pipecat.pipeline.task import PipelineParams, PipelineTask
+    from pipecat.services.google.gemini_live.llm import (
+        GeminiLiveLLMService,
+    )
+except ImportError as e:
+    logger.error(f"Missing pipecat-ai[google]: {e}")
+    logger.error("Install with: pip install 'pipecat-ai[google]'")
+    sys.exit(1)
+
+# ── Config ──────────────────────────────────────────────────────────────────
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+LAUNCHER_PORT = 8766
+WS_PORT = 8767
+LAUNCHER_BASE = f"http://localhost:{LAUNCHER_PORT}"
+BROWSER_AUDIO_SAMPLE_RATE = 8000
+BROWSER_AUDIO_CHANNELS = 1
+
+
+def load_config():
+    cfg_path = os.path.join(SCRIPT_DIR, "config.json")
+    try:
+        with open(cfg_path) as f:
+            return json.load(f)
+    except Exception:
+        logger.error("config.json not found or invalid")
+        return {}
+
+
+def _float32_b64_to_pcm16(audio_b64: str) -> bytes:
+    """Convert jarvis_web.html float32 base64 chunks to 16-bit PCM frames."""
+    raw = base64.b64decode(audio_b64)
+    if len(raw) % 4:
+        raise ValueError("audio payload length is not aligned to float32 samples")
+    samples = struct.unpack(f"<{len(raw) // 4}f", raw)
+    pcm = bytearray(len(samples) * 2)
+    offset = 0
+    for sample in samples:
+        clamped = max(-1.0, min(1.0, float(sample)))
+        pcm[offset:offset + 2] = int(clamped * 32767).to_bytes(
+            2, "little", signed=True
+        )
+        offset += 2
+    return bytes(pcm)
+
+
+# ── Tool implementations ────────────────────────────────────────────────────
+async def open_browser(url: str, tab_name: str = "JARVIS Result"):
+    """Open a URL in a Chrome slot via the launcher HTTP server."""
+    try:
+        resp = requests.post(
+            f"{LAUNCHER_BASE}/open_window",
+            json={"url": url, "label": tab_name},
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            return f"Opened {url} in browser"
+        return f"Failed to open browser: HTTP {resp.status_code}"
+    except requests.RequestException as e:
+        return f"Browser launcher unavailable: {e}"
+
+
+async def close_tabs(auto: bool = False):
+    """Close all Chrome slot windows."""
+    try:
+        resp = requests.post(
+            f"{LAUNCHER_BASE}/close_tabs",
+            json={"auto": auto},
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            return "Browser tabs closed"
+        return f"Failed to close tabs: HTTP {resp.status_code}"
+    except requests.RequestException as e:
+        return f"Browser launcher unavailable: {e}"
+
+
+async def run_playwright(action: str, params: str = "{}"):
+    """Execute a Playwright browser action via the launcher."""
+    try:
+        action_params = json.loads(params) if isinstance(params, str) else params
+        resp = requests.post(
+            f"{LAUNCHER_BASE}/playwright_action",
+            json={"action": action, "params": action_params},
+            timeout=10,
+        )
+        if resp.status_code in (200, 201):
+            return f"Playwright action '{action}' submitted"
+        return f"Playwright action failed: HTTP {resp.status_code}"
+    except requests.RequestException as e:
+        return f"Launcher unavailable: {e}"
+
+
+async def open_file(path: str):
+    """Open a file via the launcher file_action endpoint."""
+    try:
+        resp = requests.post(
+            f"{LAUNCHER_BASE}/file_action",
+            json={"action": "open", "path": path},
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            return f"Opened file: {path}"
+        return f"File action failed: HTTP {resp.status_code}"
+    except requests.RequestException as e:
+        return f"Launcher unavailable: {e}"
+
+
+# ── Tool definitions for Gemini ─────────────────────────────────────────────
+TOOLS_SCHEMA = ToolsSchema(
+    standard_tools=[
+        FunctionSchema(
+            name="open_browser",
+            description="Open a URL in the Chrome browser grid. Use when the user asks to open a website or search the web.",
+            properties={
+                "url": {
+                    "type": "string",
+                    "description": "Full URL to open (include https://)",
+                },
+                "tab_name": {
+                    "type": "string",
+                    "description": "Display name for the browser tab",
+                },
+            },
+            required=["url"],
+        ),
+        FunctionSchema(
+            name="close_tabs",
+            description="Close all browser slot windows opened by JARVIS.",
+            properties={
+                "auto": {
+                    "type": "boolean",
+                    "description": "If true, only close auto-closeable tabs",
+                },
+            },
+            required=[],
+        ),
+        FunctionSchema(
+            name="run_playwright",
+            description="Execute a Playwright browser automation action (navigate, click, fill, get_text, screenshot).",
+            properties={
+                "action": {
+                    "type": "string",
+                    "description": "Playwright action type",
+                    "enum": [
+                        "navigate",
+                        "click",
+                        "fill",
+                        "get_text",
+                        "screenshot",
+                        "open_url",
+                        "wait",
+                    ],
+                },
+                "params": {
+                    "type": "string",
+                    "description": "JSON string with action parameters",
+                },
+            },
+            required=["action"],
+        ),
+        FunctionSchema(
+            name="open_file",
+            description="Open a file on the user's computer.",
+            properties={
+                "path": {
+                    "type": "string",
+                    "description": "Full path to the file to open",
+                },
+            },
+            required=["path"],
+        ),
+    ]
+)
+
+TOOL_MAP = {
+    "open_browser": open_browser,
+    "close_tabs": close_tabs,
+    "run_playwright": run_playwright,
+    "open_file": open_file,
+}
+
+
+# ── Pipecat pipeline ────────────────────────────────────────────────────────
+class JarvisGeminiPipeline:
+    """Builds and manages the Pipecat pipeline for Gemini-powered voice AI."""
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "models/gemini-2.5-flash-native-audio-preview-12-2025",
+    ):
+        self.api_key = api_key
+        self.model = model
+        self.pipeline = None
+        self.task = None
+        self.runner = None
+
+    async def _handle_function_call(self, function_name, tool_call_id, arguments):
+        """Execute a function called by Gemini and return the result."""
+        func = TOOL_MAP.get(function_name)
+        if not func:
+            return {"error": f"Unknown function: {function_name}"}
+
+        logger.info(f"Tool call: {function_name}({arguments})")
+        try:
+            if isinstance(arguments, str):
+                arguments = json.loads(arguments)
+            result = await func(**arguments)
+            logger.info(f"Tool result: {result}")
+            return {"result": result}
+        except Exception as e:
+            logger.error(f"Tool error: {e}")
+            return {"error": str(e)}
+
+    def build(self):
+        """Construct the Pipecat pipeline with Gemini + tool calling."""
+        system_instruction = (
+            "You are JARVIS, an AI voice assistant. You can open browsers, close tabs, "
+            "run web automation, and open files on the user's computer. "
+            "Be helpful, concise, and conversational. When you perform an action, "
+            "tell the user what you're doing."
+        )
+        llm = GeminiLiveLLMService(
+            api_key=self.api_key,
+            model=self.model,
+            system_instruction=system_instruction,
+            tools=TOOLS_SCHEMA,
+            voice_id="Kore",
+        )
+
+        # Register tool call handler
+        @llm.event_handler("on_function_call")
+        async def on_tool_call(service, function_name, tool_call_id, arguments):
+            return await self._handle_function_call(function_name, tool_call_id, arguments)
+
+        self.pipeline = Pipeline([llm])
+        self.task = PipelineTask(
+            self.pipeline,
+            params=PipelineParams(
+                allow_interruptions=True,
+                enable_metrics=True,
+                enable_usage_metrics=True,
+            ),
+        )
+        self.runner = PipelineRunner()
+        return self
+
+    async def run(self):
+        """Start the pipeline runner."""
+        if not self.runner or not self.task:
+            self.build()
+        logger.info("Starting Gemini Pipecat pipeline...")
+        await self.runner.run(self.task)
+
+
+# ── WebSocket bridge (jarvis_web.html compatible) ───────────────────────────
+class JarvisWebSocketBridge:
+    """
+    Bridges jarvis_web.html's audio WebSocket to the Pipecat pipeline.
+    Provides a local WS server on port 8767 that accepts audio chunks
+    and forwards them through the pipeline.
+    """
+
+    def __init__(self, pipeline: JarvisGeminiPipeline):
+        self.pipeline = pipeline
+        self._clients: set = set()
+
+    async def handle_ws(self, websocket):
+        """Handle a connection from jarvis_web.html."""
+        self._clients.add(websocket)
+        logger.info(f"Web client connected ({len(self._clients)} active)")
+
+        try:
+            async for message in websocket:
+                try:
+                    data = json.loads(message)
+                    msg_type = data.get("type", "")
+
+                    if msg_type == "audio" or data.get("event") == "media":
+                        media = data.get("media") if isinstance(data.get("media"), dict) else {}
+                        audio_b64 = data.get("data") or media.get("payload", "")
+                        if not audio_b64:
+                            continue
+                        pcm_audio = _float32_b64_to_pcm16(audio_b64)
+                        if self.pipeline.task:
+                            await self.pipeline.task.queue_frame(
+                                InputAudioRawFrame(
+                                    audio=pcm_audio,
+                                    sample_rate=BROWSER_AUDIO_SAMPLE_RATE,
+                                    num_channels=BROWSER_AUDIO_CHANNELS,
+                                )
+                            )
+
+                    elif msg_type == "text":
+                        if self.pipeline.task:
+                            await self.pipeline.task.queue_frame(
+                                InputTextRawFrame(data.get("text", ""))
+                            )
+
+                    elif msg_type == "stop":
+                        if self.pipeline.task:
+                            await self.pipeline.task.queue_frame(InterruptionFrame())
+
+                except json.JSONDecodeError:
+                    continue
+
+        except websockets.exceptions.ConnectionClosed:
+            pass
+        finally:
+            self._clients.discard(websocket)
+            logger.info(f"Web client disconnected ({len(self._clients)} active)")
+
+    async def start_server(self):
+        """Start the WebSocket server for jarvis_web.html."""
+        logger.info(f"WebSocket bridge listening on ws://localhost:{WS_PORT}")
+        async with websockets.serve(self.handle_ws, "localhost", WS_PORT):
+            await asyncio.Future()  # run forever
+
+
+# ── Main entry point ────────────────────────────────────────────────────────
+def main():
+    config = load_config()
+
+    api_key = config.get("GEMINI_API_KEY") or os.environ.get("GEMINI_API_KEY", "")
+    if not api_key:
+        logger.error(
+            "GEMINI_API_KEY not found in config.json or GEMINI_API_KEY env var.\n"
+            "Get a free key at https://aistudio.google.com/apikey"
+        )
+        sys.exit(1)
+
+    logger.info("=== JARVIS Pipecat/Gemini Backend ===")
+    logger.info(f"Launcher HTTP: {LAUNCHER_BASE}")
+    logger.info(f"WebSocket:     ws://localhost:{WS_PORT}")
+
+    async def run_all():
+        pipeline = JarvisGeminiPipeline(api_key=api_key)
+        pipeline.build()
+
+        bridge = JarvisWebSocketBridge(pipeline)
+
+        # Run pipeline and WS bridge concurrently
+        await asyncio.gather(
+            pipeline.run(),
+            bridge.start_server(),
+        )
+
+    asyncio.run(run_all())
+
+
+if __name__ == "__main__":
+    main()

--- a/test_pipecat_gemini.py
+++ b/test_pipecat_gemini.py
@@ -1,0 +1,140 @@
+import asyncio
+import base64
+import importlib
+import json
+import struct
+import sys
+import types
+import unittest
+
+
+class DummyInputAudioRawFrame:
+    def __init__(self, audio, sample_rate, num_channels):
+        self.audio = audio
+        self.sample_rate = sample_rate
+        self.num_channels = num_channels
+
+
+class DummyInputTextRawFrame:
+    def __init__(self, text):
+        self.text = text
+
+
+class DummyInterruptionFrame:
+    pass
+
+
+class DummyGeminiLiveLLMService:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def event_handler(self, _event_name):
+        def decorator(func):
+            return func
+        return decorator
+
+
+def _install_pipecat_stubs():
+    def module(name):
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+        return mod
+
+    module("pipecat")
+    module("pipecat.adapters")
+    module("pipecat.adapters.schemas")
+
+    function_schema = module("pipecat.adapters.schemas.function_schema")
+    function_schema.FunctionSchema = lambda **kwargs: kwargs
+
+    tools_schema = module("pipecat.adapters.schemas.tools_schema")
+    tools_schema.ToolsSchema = lambda **kwargs: kwargs
+
+    silero = module("pipecat.audio.vad.silero")
+    silero.SileroVADAnalyzer = object
+    module("pipecat.audio")
+    module("pipecat.audio.vad")
+
+    frames = module("pipecat.frames.frames")
+    frames.InputAudioRawFrame = DummyInputAudioRawFrame
+    frames.InputTextRawFrame = DummyInputTextRawFrame
+    frames.InterruptionFrame = DummyInterruptionFrame
+    module("pipecat.frames")
+
+    pipeline_mod = module("pipecat.pipeline.pipeline")
+    pipeline_mod.Pipeline = lambda components: components
+    runner_mod = module("pipecat.pipeline.runner")
+    runner_mod.PipelineRunner = object
+    task_mod = module("pipecat.pipeline.task")
+    task_mod.PipelineParams = lambda **kwargs: kwargs
+    task_mod.PipelineTask = lambda pipeline, params=None: types.SimpleNamespace(
+        pipeline=pipeline,
+        params=params,
+    )
+    module("pipecat.pipeline")
+
+    llm_mod = module("pipecat.services.google.gemini_live.llm")
+    llm_mod.GeminiLiveLLMService = DummyGeminiLiveLLMService
+    module("pipecat.services")
+    module("pipecat.services.google")
+    module("pipecat.services.google.gemini_live")
+
+
+_install_pipecat_stubs()
+pipecat_gemini = importlib.import_module("pipecat_gemini")
+
+
+class FakeTask:
+    def __init__(self):
+        self.frames = []
+
+    async def queue_frame(self, frame):
+        self.frames.append(frame)
+
+
+class FakeWebSocket:
+    def __init__(self, messages):
+        self._messages = iter(messages)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._messages)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class PipecatGeminiBridgeTest(unittest.TestCase):
+    def test_float32_base64_audio_is_converted_to_pcm16(self):
+        payload = base64.b64encode(struct.pack("<4f", -1.0, 0.0, 0.5, 1.25)).decode()
+
+        pcm = pipecat_gemini._float32_b64_to_pcm16(payload)
+
+        self.assertEqual(
+            pcm,
+            b"\x01\x80\x00\x00\xff?\xff\x7f",
+        )
+
+    def test_websocket_audio_messages_are_forwarded_to_pipeline(self):
+        task = FakeTask()
+        pipeline = types.SimpleNamespace(task=task)
+        bridge = pipecat_gemini.JarvisWebSocketBridge(pipeline)
+        payload = base64.b64encode(struct.pack("<1f", 0.25)).decode()
+        websocket = FakeWebSocket([
+            json.dumps({"type": "audio", "data": payload}),
+        ])
+
+        asyncio.run(bridge.handle_ws(websocket))
+
+        self.assertEqual(len(task.frames), 1)
+        frame = task.frames[0]
+        self.assertIsInstance(frame, DummyInputAudioRawFrame)
+        self.assertEqual(frame.sample_rate, pipecat_gemini.BROWSER_AUDIO_SAMPLE_RATE)
+        self.assertEqual(frame.num_channels, pipecat_gemini.BROWSER_AUDIO_CHANNELS)
+        self.assertEqual(frame.audio, b"\xff\x1f")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_scheduled_actions.py
+++ b/test_scheduled_actions.py
@@ -70,6 +70,18 @@ class ScheduledActionsTest(unittest.TestCase):
         self.assertTrue(jarvis_launcher.cancel_scheduled_action(item["id"]))
         self.assertEqual(jarvis_launcher.list_scheduled_actions()[0]["status"], "cancelled")
 
+    def test_playwright_action_uses_immediate_schedule(self):
+        now = datetime(2026, 6, 3, 12, 0, tzinfo=timezone.utc)
+
+        item = jarvis_launcher.create_playwright_action(
+            {"action": "navigate", "params": {"url": "https://example.com"}},
+            now=now,
+        )
+
+        self.assertEqual(item["name"], "playwright: navigate")
+        self.assertEqual(item["scheduled_for"], "2026-06-03T12:00:00+00:00")
+        self.assertEqual(item["actions"], [{"type": "open_url", "url": "https://example.com"}])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- adds a scoped `pipecat_gemini` backend switch via `config.json`
- forwards browser `event: media` audio chunks into Pipecat `InputAudioRawFrame`s
- registers Gemini tools with `FunctionSchema` / `ToolsSchema`
- routes Gemini Playwright tool calls through `/playwright_action`

## Validation
- `python -m py_compile ./jarvis_launcher.py ./pipecat_gemini.py ./test_scheduled_actions.py`
- `python -m unittest test_scheduled_actions.py`
- checked `pipecat-ai 1.3.0` schema/frame APIs locally

Fixes #11