### PR TITLE
Add cross-platform release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,209 @@
+name: Build & Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g. v2.1.0)"
+        required: true
+        default: "v2.1.0"
+
+permissions:
+  contents: write
+
+env:
+  RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install pyaudio numpy websocket-client rich SpeechRecognition playwright playwright-stealth
+          choco install nsis -y
+
+      - name: Build with PyInstaller
+        run: pyinstaller jarvis.spec --clean --noconfirm
+
+      - name: Package Windows artifacts
+        shell: pwsh
+        run: |
+          $version = $env:RELEASE_VERSION
+          $version = $version -replace '^v', ''
+          Compress-Archive -Path dist\JARVIS\* -DestinationPath "JARVIS-$version-win64-portable.zip"
+          @"
+          !define APP_NAME "JARVIS"
+          !define VERSION "$version"
+          Name "JARVIS"
+          OutFile "JARVIS-$version-windows-installer.exe"
+          InstallDir "`$LOCALAPPDATA\JARVIS"
+          RequestExecutionLevel user
+          Section "Install"
+            SetOutPath "`$INSTDIR"
+            File /r "dist\JARVIS\*"
+            CreateShortcut "`$DESKTOP\JARVIS.lnk" "`$INSTDIR\JARVIS.exe"
+          SectionEnd
+          "@ | Set-Content installer.nsi
+          makensis installer.nsi
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: JARVIS-windows
+          path: |
+            JARVIS-*-win64-portable.zip
+            JARVIS-*-windows-installer.exe
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install system dependencies
+        run: brew install portaudio
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install pyaudio numpy websocket-client rich SpeechRecognition playwright playwright-stealth
+
+      - name: Build with PyInstaller
+        run: pyinstaller jarvis.spec --clean --noconfirm
+
+      - name: Create DMG
+        run: |
+          VERSION="${RELEASE_VERSION}"
+          VERSION=$(echo "$VERSION" | sed 's/^v//')
+          mkdir -p dmg_staging
+          cp -R dist/JARVIS/* dmg_staging/
+          cp JARVIS.command dmg_staging/
+          cp setup_mac.sh dmg_staging/
+          chmod +x dmg_staging/JARVIS dmg_staging/JARVIS.command dmg_staging/setup_mac.sh
+          hdiutil create -volname "JARVIS" -srcfolder dmg_staging -ov -format UDZO "JARVIS-${VERSION}-macos.dmg"
+
+      - name: Upload DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: JARVIS-macos-dmg
+          path: JARVIS-*-macos.dmg
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev python3-pyaudio python3-dev binutils
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install pyaudio numpy websocket-client rich SpeechRecognition playwright playwright-stealth
+
+      - name: Build with PyInstaller
+        run: pyinstaller jarvis.spec --clean --noconfirm
+
+      - name: Package as portable tarball
+        run: |
+          VERSION="${RELEASE_VERSION}"
+          VERSION=$(echo "$VERSION" | sed 's/^v//')
+          cd dist/JARVIS
+          tar czf "../../JARVIS-${VERSION}-linux-x64.tar.gz" *
+          cd ../..
+          mkdir -p debian/DEBIAN debian/usr/local/lib/jarvis debian/usr/local/bin
+          cp -R dist/JARVIS/* debian/usr/local/lib/jarvis/
+          cat > debian/DEBIAN/control <<EOF
+          Package: jarvis
+          Version: ${VERSION}
+          Section: utils
+          Priority: optional
+          Architecture: amd64
+          Maintainer: JARVIS Maintainers <noreply@github.com>
+          Description: Cross-platform JARVIS voice AI terminal
+          EOF
+          cat > debian/usr/local/bin/jarvis <<'EOF'
+          #!/usr/bin/env sh
+          exec /usr/local/lib/jarvis/JARVIS "$@"
+          EOF
+          chmod +x debian/usr/local/bin/jarvis
+          dpkg-deb --build debian "JARVIS-${VERSION}-linux-amd64.deb"
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: JARVIS-linux
+          path: |
+            JARVIS-*-linux-x64.tar.gz
+            JARVIS-*-linux-amd64.deb
+
+  create-release:
+    needs: [build-windows, build-macos, build-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Flatten artifacts
+        run: |
+          find artifacts -type f \( -name "*.zip" -o -name "*.exe" -o -name "*.dmg" -o -name "*.tar.gz" -o -name "*.deb" \) \
+            -exec cp {} ./ \;
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_VERSION }}
+          name: "JARVIS ${{ env.RELEASE_VERSION }}"
+          body: |
+            ## J.A.R.V.I.S ${{ env.RELEASE_VERSION }}
+
+            Cross-platform voice AI terminal powered by Toingg.
+
+            ### Download
+            - **Windows**: `JARVIS-*.exe` installer or portable `JARVIS-*.zip`
+            - **macOS**: `JARVIS-*.dmg` (mount and drag to Applications)
+            - **Linux**: `JARVIS-*.deb` for Debian/Ubuntu or portable `JARVIS-*.tar.gz`
+
+            ### Requirements
+            - Microphone and speakers/headphones
+            - Google Chrome, Chromium, or Edge
+            - Toingg API key (free from prepodapp.toingg.com)
+
+            See [README.md](https://github.com/PG-AGI/toingg-jarvis#readme) for full setup instructions.
+          files: |
+            *.zip
+            *.exe
+            *.dmg
+            *.tar.gz
+            *.deb
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/jarvis.spec
+++ b/jarvis.spec
@@ -1,0 +1,112 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller spec for J.A.R.V.I.S – cross-platform packaging.
+
+Build:
+    pip install pyinstaller
+    pyinstaller jarvis.spec --clean
+
+Output:
+    dist/JARVIS/  (directory)         → run `./JARVIS` or `JARVIS.exe`
+    dist/JARVIS.exe --onedir single   (add --onefile for a single binary)
+"""
+
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(SPECPATH)
+
+block_cipher = None
+
+DATA_FILES = [
+    (str(ROOT / "jarvis_web.html"), "."),
+    (str(ROOT / "jarvis_visual.html"), "."),
+    (str(ROOT / "config.example.json"), "."),
+    (str(ROOT / "REWARD_SYSTEM.md"), "."),
+    (str(ROOT / "CONTRIBUTING.md"), "."),
+    (str(ROOT / "CODE_OF_CONDUCT.md"), "."),
+    (str(ROOT / "LICENSE"), "."),
+    (str(ROOT / "JARVIS.bat"), "."),
+    (str(ROOT / "JARVIS.command"), "."),
+    (str(ROOT / "setup_mac.sh"), "."),
+    (str(ROOT / "NATIVE_FILE_MANAGER.md"), "."),
+    (str(ROOT / "JARVIS_README.md"), "."),
+    (str(ROOT / "README.md"), "."),
+]
+
+HIDDEN_IMPORTS = [
+    "sounddevice",
+    "numpy",
+    "speech_recognition",
+    "websocket",
+    "playwright",
+    "playwright_stealth",
+    "rich",
+    "http.server",
+    "ctypes",
+    "json",
+    "threading",
+    "uuid",
+    "webbrowser",
+]
+
+EXCLUDES = [
+    "tkinter",
+    "test",
+    "unittest",
+    "setuptools",
+    "pip",
+]
+
+EXE_NAME = "JARVIS" if sys.platform != "win32" else "JARVIS.exe"
+
+a = Analysis(
+    [str(ROOT / "jarvis_launcher.py")],
+    pathex=[str(ROOT)],
+    binaries=[],
+    datas=DATA_FILES,
+    hiddenimports=HIDDEN_IMPORTS,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=EXCLUDES,
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="JARVIS",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="JARVIS",
+)


### PR DESCRIPTION
## Summary
- adds a GitHub Actions release workflow for Windows, macOS, and Linux
- builds PyInstaller artifacts from a shared `jarvis.spec`
- publishes Windows installer/portable ZIP, macOS DMG, Linux `.deb` and portable tarball
- supports tag pushes and manual `workflow_dispatch` releases with a version input

## Validation
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/release.yml').read_text())"`
- `python -m py_compile ./jarvis.spec`
- `git diff --cached --check`

Fixes #13