### PR TITLE
fix: cleanup browserClient.py and jarvis_launcher.py

### DIFF
--- a/browserClient.py
+++ b/browserClient.py
@@ -1,11 +1,11 @@
 """
-claudeBot.py — Browser automation client for the Toingg personal AI assistant.
+browserClient.py — Browser automation client for the Toingg personal AI assistant.
 
 Connects to the backend WebSocket, receives Playwright-compatible commands from the LLM,
 executes them in a real browser, and returns results.
 
 Usage:
-    python claudeBot.py --url ws://localhost:8002/api/v3/media/browser/default
+    python browserClient.py --url ws://localhost:8002/api/v3/media/browser/default
 
 Requirements:
     pip install websocket-client playwright playwright-stealth
@@ -1182,7 +1182,7 @@ class BrowserClient:
     def _on_message(self, ws, raw: str):
         try:
             msg = json.loads(raw)
-            print("Received: ", msg)
+            log.debug("Received: %s", msg)
         except json.JSONDecodeError:
             return
 

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -832,10 +832,8 @@ def start_http_server():
                     self.end_headers()
                     self.wfile.write(json.dumps({"ok": cancelled}).encode())
                 except Exception as e:
+                    print(f"  [schedule] cancel error: {e}")
                     self.send_response(400)
-                except Exception as e:
-                    print(f"  [file] unexpected error: {e}")
-                    self.send_response(500)
                     self.send_header("Content-Type", "application/json")
                     self._cors()
                     self.end_headers()
@@ -1069,7 +1067,9 @@ def voice_listener():
     recognizer.non_speaking_duration    = 0.8
     recognizer.phrase_threshold         = 0.3
     print("  [voice] 🎙  Listening for: hey jarvis / jarvis...")
-
+    # Initialise once outside the loop — re-opening the audio device every cycle
+    # causes churn and can crash on some systems.
+    mic = sr.Microphone(sample_rate=16000)
     while True:
         if stop_capture.is_set():
             print("  [voice] ⏸  Mic paused. Press Enter to resume...")
@@ -1077,7 +1077,6 @@ def voice_listener():
             stop_capture.clear()
             print("  [voice] ▶  Resumed.\n")
         try:
-            mic = sr.Microphone(sample_rate=16000)
             with mic as source:
                 recognizer.adjust_for_ambient_noise(source, duration=0.5)
             with mic as source2:


### PR DESCRIPTION
# Pull Request

## Linked Issue
No existing issues — bugs identified during manual code review of the full codebase.
---
## Summary of Changes
- Fix wrong module docstring in `browserClient.py` (said `claudeBot.py`, should be `browserClient.py`)
- Replace `print()` with `log.debug()` in `_on_message` to stop WebSocket payloads leaking to stdout on every message
- Move `sr.Microphone()` outside the `while True` loop in `voice_listener()` to prevent audio device churn on every listen cycle
- Fix duplicate `except Exception` block in `/cancel_scheduled_action` HTTP handler — second block was unreachable, and first block was missing `end_headers()`, causing the response to hang
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor/code cleanup
---
## Testing Performed
- [x] Tested on **Windows**
- Platform tested on: Windows 11
- Python version: 3.11
Steps to verify:
1. Run `jarvis_launcher.py` — voice listener no longer re-opens audio device on every listen cycle
2. Run `browserClient.py` — WebSocket messages no longer flood stdout
3. POST to `/cancel_scheduled_action` with invalid payload — server now returns proper JSON error response instead of hanging
---
## Checklist
- [x] I have performed a self-review of my code
- [x] I have commented on any non-obvious logic
- [x] My changes do not introduce new warnings or errors
- [x] I have tested this on at least one supported platform
- [x] I have not committed secrets, API keys, or personal config files