### PR TITLE
feat: add scoped Pipecat/Gemini bridge

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,7 @@
 {
   "WS_URL": "wss://prepodapi.toingg.com/api/v3/media/streaming",
   "TOKEN":  "your-token-here",
-  "CAMP_ID": "your-campaign-id-here"
+  "CAMP_ID": "your-campaign-id-here",
+  "BACKEND": "toingg",
+  "GEMINI_API_KEY": "your-gemini-api-key-here"
 }

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -545,6 +545,8 @@ def start_scheduler():
 _visual_proc = None
 _web_proc    = None
 _browser_client_proc = None
+PIPECAT_GEMINI_SCRIPT = os.path.join(_DIR, "pipecat_gemini.py")
+_pipecat_proc = None
 
 def start_browser_client():
     """Start browserClient.py in the background for browser automation."""
@@ -559,6 +561,35 @@ def start_browser_client():
         print("  [browser] ✅ browserClient.py started")
     except Exception as e:
         print(f"  [browser] ⚠  Failed to start browserClient.py: {e}")
+
+def _load_config():
+    cfg_path = os.path.join(_DIR, "config.json")
+    try:
+        with open(cfg_path, "r") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+def _is_pipecat_backend():
+    cfg = _load_config()
+    backend = str(cfg.get("BACKEND", "")).strip().lower()
+    if backend != "pipecat_gemini":
+        return False
+    api_key = os.environ.get("GEMINI_API_KEY") or str(cfg.get("GEMINI_API_KEY", "")).strip()
+    return bool(api_key and api_key != "your-gemini-api-key-here")
+
+def start_pipecat_backend():
+    """Start the optional local Pipecat/Gemini bridge."""
+    global _pipecat_proc
+    if _pipecat_proc and _pipecat_proc.poll() is None:
+        print("  [pipecat] already running"); return
+    if not os.path.exists(PIPECAT_GEMINI_SCRIPT):
+        print("  [pipecat] ⚠  pipecat_gemini.py not found"); return
+    try:
+        _pipecat_proc = subprocess.Popen([sys.executable, PIPECAT_GEMINI_SCRIPT], cwd=_DIR)
+        print("  [pipecat] ✅ Gemini backend started")
+    except Exception as e:
+        print(f"  [pipecat] ⚠  Failed to start Gemini backend: {e}")
 
 def open_jarvis_visual():
     """Open jarvis_visual.html at the top-center of the screen — the main visible window."""
@@ -791,6 +822,37 @@ def start_http_server():
                 self._cors()
                 self.end_headers()
                 self.wfile.write(b'{"ok":true}')
+
+            elif self.path == "/playwright_action":
+                try:
+                    payload = json.loads(body) if body else {}
+                    if not isinstance(payload, dict):
+                        raise ValueError("payload must be a JSON object")
+                    action_type = str(payload.get("action") or payload.get("type") or "").strip().lower()
+                    params = payload.get("params") or {}
+                    if not action_type:
+                        raise ValueError("action is required")
+                    if not isinstance(params, dict):
+                        raise ValueError("params must be a JSON object")
+                    item = create_scheduled_action(
+                        {
+                            "name": f"playwright: {action_type}",
+                            "trigger": {"delay_seconds": 0},
+                            "actions": [{"type": action_type, **params}],
+                        }
+                    )
+                    self.send_response(202)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"ok": True, "item": item}).encode())
+                except Exception as e:
+                    print(f"  [playwright] action error: {e}")
+                    self.send_response(400)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"ok": False, "error": str(e)}).encode())
 
             elif self.path == "/schedule_action":
                 try:
@@ -1028,6 +1090,9 @@ def full_launch(source):
     print(f"\n  🚀  [{source}] JARVIS ACTIVATED\n")
 
     def sequence():
+        if _is_pipecat_backend():
+            print("  [pipecat] Launching Gemini backend...")
+            start_pipecat_backend()
         print("  [1/3] Browser automation client...")
         start_browser_client()
         print("  [2/3] JARVIS Visual window...")

--- a/jarvis_web.html
+++ b/jarvis_web.html
@@ -1611,9 +1611,15 @@ async function loadConfig() {
   const res = await fetch("config.json");
   if (!res.ok) throw new Error(`config.json not found (${res.status})`);
   const cfg = await res.json();
-  WS_URL  = cfg.WS_URL  || "";
   TOKEN   = cfg.TOKEN   || "";
   CAMP_ID = cfg.CAMP_ID || "";
+  const backend = String(cfg.BACKEND || "toingg").toLowerCase();
+  if (backend === "pipecat_gemini") {
+    WS_URL = "ws://localhost:8767";
+    logChat("sys", "◈ PIPECAT/GEMINI BACKEND ENABLED");
+  } else {
+    WS_URL = cfg.WS_URL || "";
+  }
 }
 
 async function boot() {

--- a/pipecat_gemini.py
+++ b/pipecat_gemini.py
@@ -1,0 +1,300 @@
+"""
+Optional Pipecat/Gemini backend for J.A.R.V.I.S.
+
+Model assisted: GPT-5.
+
+This module keeps the existing Toingg backend as the default. When
+config.json sets BACKEND=pipecat_gemini, jarvis_web.html connects to this
+local WebSocket bridge and Gemini tool calls are routed to the launcher HTTP
+API on localhost:8766.
+"""
+
+import asyncio
+import base64
+import json
+import os
+import struct
+import sys
+from urllib import request
+from urllib.error import URLError
+
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+LAUNCHER_BASE = "http://localhost:8766"
+WS_PORT = 8767
+DEFAULT_MODEL = "gemini-2.5-flash"
+
+
+TOOL_DECLARATIONS = [
+    {
+        "name": "open_browser",
+        "description": "Open one or more URLs in the JARVIS browser grid.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "url": {"type": "string"},
+                "urls": {"type": "array", "items": {"type": "string"}},
+                "tabs": {"type": "array", "items": {"type": "object"}},
+            },
+        },
+    },
+    {
+        "name": "close_tabs",
+        "description": "Close browser slot windows opened by JARVIS.",
+        "parameters": {
+            "type": "object",
+            "properties": {"auto": {"type": "boolean"}},
+        },
+    },
+    {
+        "name": "open_file",
+        "description": "Open a local file through the launcher's native file handler.",
+        "parameters": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "run_playwright",
+        "description": "Run a browser automation action through /playwright_action.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {"type": "string"},
+                "params": {"type": "object"},
+            },
+            "required": ["action"],
+        },
+    },
+]
+
+
+def load_config():
+    try:
+        with open(os.path.join(SCRIPT_DIR, "config.json"), "r") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def post_json(url, payload, timeout=10):
+    data = json.dumps(payload).encode("utf-8")
+    req = request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            try:
+                body = json.loads(raw) if raw else {}
+            except json.JSONDecodeError:
+                body = {"raw": raw}
+            return {"ok": 200 <= resp.status < 300, "status": resp.status, "body": body}
+    except URLError as exc:
+        return {"ok": False, "status": 0, "error": str(exc)}
+
+
+class LauncherToolClient:
+    def __init__(self, base_url=LAUNCHER_BASE, poster=post_json):
+        self.base_url = base_url.rstrip("/")
+        self.poster = poster
+
+    def open_browser(self, arguments):
+        tabs = arguments.get("tabs")
+        if tabs is None:
+            urls = arguments.get("urls")
+            if urls is None:
+                urls = [arguments["url"]]
+            tabs = [{"url": url} for url in urls]
+        return self.poster(f"{self.base_url}/open_tabs", tabs[:4])
+
+    def close_tabs(self, arguments):
+        return self.poster(
+            f"{self.base_url}/close_tabs",
+            {"auto": bool(arguments.get("auto", False))},
+        )
+
+    def open_file(self, arguments):
+        return self.poster(
+            f"{self.base_url}/file_action",
+            {"action": "open_file", "path": arguments["path"]},
+        )
+
+    def run_playwright(self, arguments):
+        return self.poster(
+            f"{self.base_url}/playwright_action",
+            {
+                "action": arguments["action"],
+                "params": arguments.get("params") or {},
+            },
+        )
+
+
+TOOL_METHODS = {
+    "open_browser": "open_browser",
+    "close_tabs": "close_tabs",
+    "open_file": "open_file",
+    "run_playwright": "run_playwright",
+    "playwright_action": "run_playwright",
+}
+
+
+async def handle_tool_call(function_name, arguments, tool_call_id="", client=None):
+    if isinstance(arguments, str):
+        arguments = json.loads(arguments or "{}")
+    if arguments is None:
+        arguments = {}
+    if not isinstance(arguments, dict):
+        raise ValueError("tool arguments must be a JSON object")
+    client = client or LauncherToolClient()
+    method_name = TOOL_METHODS.get(function_name)
+    if not method_name:
+        result = {"ok": False, "error": f"unknown tool: {function_name}"}
+    else:
+        method = getattr(client, method_name)
+        result = method(arguments)
+    return {
+        "type": "FunctionCallResultFrame",
+        "function_name": function_name,
+        "tool_call_id": tool_call_id,
+        "result": result,
+    }
+
+
+def float32_b64_to_pcm16(payload):
+    raw = base64.b64decode(payload)
+    if len(raw) % 4:
+        raise ValueError("Float32 audio payload length must be divisible by 4")
+    values = struct.unpack("<" + "f" * (len(raw) // 4), raw)
+    pcm = bytearray()
+    for value in values:
+        value = max(-1.0, min(1.0, float(value)))
+        pcm.extend(struct.pack("<h", int(value * 32767)))
+    return bytes(pcm)
+
+
+async def queue_audio_frame(task, payload, sample_rate=16000, channels=1, frame_class=None):
+    frame_class = frame_class or _load_input_audio_frame_class()
+    audio = float32_b64_to_pcm16(payload)
+    frame = frame_class(audio=audio, sample_rate=sample_rate, num_channels=channels)
+    await task.queue_frame(frame)
+    return frame
+
+
+def _load_input_audio_frame_class():
+    from pipecat.frames.frames import InputAudioRawFrame
+
+    return InputAudioRawFrame
+
+
+def _load_input_text_frame_class():
+    from pipecat.frames.frames import InputTextRawFrame
+
+    return InputTextRawFrame
+
+
+def _load_interruption_frame_class():
+    from pipecat.frames.frames import InterruptionFrame
+
+    return InterruptionFrame
+
+
+class JarvisWebSocketBridge:
+    def __init__(self, task, clients=None, audio_frame_class=None, text_frame_class=None, interruption_frame_class=None):
+        self.task = task
+        self.clients = clients if clients is not None else set()
+        self.audio_frame_class = audio_frame_class
+        self.text_frame_class = text_frame_class
+        self.interruption_frame_class = interruption_frame_class
+
+    async def handle_message(self, message):
+        data = json.loads(message) if isinstance(message, str) else message
+        event = str(data.get("event") or data.get("type") or "").lower()
+        if event in ("media", "audio"):
+            payload = data.get("media", {}).get("payload") or data.get("data") or data.get("payload")
+            if not payload:
+                return None
+            sample_rate = int(data.get("sampleRate") or data.get("sample_rate") or 16000)
+            return await queue_audio_frame(
+                self.task,
+                payload,
+                sample_rate=sample_rate,
+                frame_class=self.audio_frame_class,
+            )
+        if event == "text":
+            frame_class = self.text_frame_class or _load_input_text_frame_class()
+            frame = frame_class(data.get("text", ""))
+            await self.task.queue_frame(frame)
+            return frame
+        if event in ("stop", "interrupt"):
+            frame_class = self.interruption_frame_class or _load_interruption_frame_class()
+            frame = frame_class()
+            await self.task.queue_frame(frame)
+            return frame
+        return None
+
+    async def handle_ws(self, websocket):
+        self.clients.add(websocket)
+        try:
+            async for message in websocket:
+                await self.handle_message(message)
+        finally:
+            self.clients.discard(websocket)
+
+
+async def run_backend():
+    try:
+        import websockets
+        from pipecat.pipeline.pipeline import Pipeline
+        from pipecat.pipeline.runner import PipelineRunner
+        from pipecat.pipeline.task import PipelineParams, PipelineTask
+        from pipecat.services.google.gemini_live.llm import GeminiLiveLLMService, GeminiLiveLLMSettings
+    except ImportError as exc:
+        print(f"Missing optional Pipecat/Gemini dependency: {exc}", file=sys.stderr)
+        print("Install with: pip install 'pipecat-ai[google]' websockets", file=sys.stderr)
+        sys.exit(1)
+
+    cfg = load_config()
+    api_key = os.environ.get("GEMINI_API_KEY") or cfg.get("GEMINI_API_KEY", "")
+    if not api_key or api_key == "your-gemini-api-key-here":
+        print("GEMINI_API_KEY is required for BACKEND=pipecat_gemini", file=sys.stderr)
+        sys.exit(1)
+
+    settings = GeminiLiveLLMSettings(
+        api_key=api_key,
+        model=cfg.get("GEMINI_MODEL", DEFAULT_MODEL),
+        tools=TOOL_DECLARATIONS,
+        modalities=["AUDIO"],
+    )
+    llm = GeminiLiveLLMService(settings=settings)
+    client = LauncherToolClient()
+
+    @llm.event_handler("on_function_call")
+    async def on_function_call(service, function_name, tool_call_id, arguments):
+        return await handle_tool_call(function_name, arguments, tool_call_id, client=client)
+
+    pipeline = Pipeline([llm])
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(allow_interruptions=True, enable_metrics=True),
+    )
+    bridge = JarvisWebSocketBridge(task)
+    runner = PipelineRunner()
+
+    async def serve_ws():
+        async with websockets.serve(bridge.handle_ws, "localhost", WS_PORT):
+            await asyncio.Future()
+
+    await asyncio.gather(runner.run(task), serve_ws())
+
+
+def main():
+    asyncio.run(run_backend())
+
+
+if __name__ == "__main__":
+    main()

--- a/test_pipecat_gemini.py
+++ b/test_pipecat_gemini.py
@@ -1,0 +1,86 @@
+import asyncio
+import base64
+import json
+import struct
+import unittest
+
+from pipecat_gemini import JarvisWebSocketBridge, LauncherToolClient, handle_tool_call
+
+
+class FakeFrame:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class FakeTask:
+    def __init__(self):
+        self.frames = []
+
+    async def queue_frame(self, frame):
+        self.frames.append(frame)
+
+
+class PipecatGeminiTests(unittest.TestCase):
+    def test_tool_calls_route_to_launcher_endpoints(self):
+        calls = []
+
+        def poster(url, payload):
+            calls.append((url, payload))
+            return {"ok": True}
+
+        client = LauncherToolClient("http://launcher", poster=poster)
+
+        result = asyncio.run(
+            handle_tool_call(
+                "run_playwright",
+                {"action": "click", "params": {"selector": "#go"}},
+                "call-1",
+                client=client,
+            )
+        )
+
+        self.assertEqual(result["tool_call_id"], "call-1")
+        self.assertEqual(
+            calls[0],
+            (
+                "http://launcher/playwright_action",
+                {"action": "click", "params": {"selector": "#go"}},
+            ),
+        )
+
+    def test_open_file_uses_native_file_endpoint_action(self):
+        calls = []
+        client = LauncherToolClient(
+            "http://launcher",
+            poster=lambda url, payload: calls.append((url, payload)) or {"ok": True},
+        )
+
+        asyncio.run(handle_tool_call("open_file", {"path": "/tmp/report.txt"}, client=client))
+
+        self.assertEqual(
+            calls[0],
+            (
+                "http://launcher/file_action",
+                {"action": "open_file", "path": "/tmp/report.txt"},
+            ),
+        )
+
+    def test_media_messages_are_forwarded_as_audio_frames(self):
+        samples = struct.pack("<ff", 0.5, -0.5)
+        payload = base64.b64encode(samples).decode("ascii")
+        task = FakeTask()
+        bridge = JarvisWebSocketBridge(task, audio_frame_class=FakeFrame)
+
+        frame = asyncio.run(
+            bridge.handle_message(json.dumps({"event": "media", "media": {"payload": payload}}))
+        )
+
+        self.assertIs(frame, task.frames[0])
+        self.assertEqual(frame.kwargs["sample_rate"], 16000)
+        self.assertEqual(frame.kwargs["num_channels"], 1)
+        self.assertEqual(len(frame.kwargs["audio"]), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #11

## Summary

- adds a scoped optional `pipecat_gemini.py` backend behind `BACKEND=pipecat_gemini`; Toingg remains the default path
- forwards `jarvis_web.html` `media` audio chunks into Pipecat audio frames instead of dropping them
- routes Gemini tool calls to launcher HTTP endpoints: `/open_tabs`, `/close_tabs`, `/file_action`, and `/playwright_action`
- adds the missing `/playwright_action` launcher endpoint and focused unit coverage for tool routing + audio forwarding

## Scope guard

This is intentionally limited to issue #11. It does not include packaging, release workflow, or debug logging changes.

## Validation

- `timeout 30s python3 -m unittest test_pipecat_gemini.py test_scheduled_actions.py test_native_file_manager.py -v`
- `python3 -m py_compile pipecat_gemini.py jarvis_launcher.py browserClient.py native_file_manager.py`
- `git diff --check`

## Demo note

The sandbox has no Gemini API key or Pipecat runtime installed, so I validated the maintainer-called-out failure points with local tests: audio media chunks are queued as audio frames, `run_playwright` uses `/playwright_action`, and `open_file` uses the launcher file action endpoint with the correct action name.
