### PR TITLE
Add secure upload tokens for browser file inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ All three layers run simultaneously and communicate over `localhost:8766`.
 **🎙️ Voice Interaction**
 - Wake-word activation — just say **"Hey Jarvis"**
 - Real-time WebSocket streaming to Toingg AI
+- Temporary image uploads for Playwright file inputs
 - Barge-in support while AI is speaking
 - SpeechRecognition + Web Speech API
 
@@ -153,6 +154,33 @@ All three layers run simultaneously and communicate over `localhost:8766`.
 </td>
 </tr>
 </table>
+
+### Uploading images for browser automation
+
+The launcher accepts PNG, JPEG, GIF, WebP, and other `image/*` uploads at
+`POST http://localhost:8766/api/uploads`. Send one or more multipart file
+fields:
+
+```bash
+curl -F "files=@screenshot.png" http://localhost:8766/api/uploads
+```
+
+The response contains an opaque token for each image. Pass either `token` or
+`tokens` to the browser WebSocket action:
+
+```json
+{
+  "action": "input_file",
+  "params": {
+    "selector": "input[type=file]",
+    "tokens": ["550e8400-e29b-41d4-a716-446655440000"]
+  }
+}
+```
+
+Each image is limited to 10 MB and each request to 25 MB. Tokens expire after
+one hour and are deleted immediately after the browser action attempts to use
+them. The API never returns or accepts server filesystem paths.
 
 ---
 

--- a/browserClient.py
+++ b/browserClient.py
@@ -24,6 +24,7 @@ import base64
 
 import websocket
 from playwright.sync_api import sync_playwright, Page, Playwright
+from upload_store import UploadStore, attach_uploaded_files
 
 # playwright-stealth >= 2.x uses `Stealth`; older 1.x used `stealth_sync`.
 try:
@@ -103,6 +104,7 @@ class BrowserClient:
         self.page: Page | None = None
         self.playwright: Playwright | None = None
         self._stop = threading.Event()
+        self.upload_store = UploadStore()
 
     def _select_active_page(self) -> Page | None:
         """Prefer the useful app tab over the initial about:blank page."""
@@ -1044,6 +1046,24 @@ class BrowserClient:
                 self._human_delay()
                 page.select_option(selector, value)
                 return {"success": True, "result": f"Selected '{value}' in '{selector}'"}
+
+            elif action in ("input_file", "set_input_files"):
+                selector = params["selector"]
+                tokens = params.get("tokens")
+                if tokens is None:
+                    token = params.get("token")
+                    tokens = [token] if token else []
+                count = attach_uploaded_files(
+                    page,
+                    self.upload_store,
+                    selector,
+                    tokens,
+                    params.get("timeout", 10000),
+                )
+                return {
+                    "success": True,
+                    "result": f"Attached {count} uploaded file(s) to '{selector}'",
+                }
 
             elif action == "scroll":
                 x = params.get("x", 0)

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -19,6 +19,12 @@ import platform as _plat
 from datetime import datetime, timedelta, timezone
 
 from native_file_manager import NativeFileActionError, handle_file_action_payload
+from upload_store import (
+    MAX_UPLOAD_REQUEST_BYTES,
+    UploadError,
+    UploadStore,
+    parse_multipart_images,
+)
 
 # ── CONFIG ────────────────────────────────────────────────────────────────────
 _DIR        = os.path.dirname(os.path.abspath(__file__))
@@ -28,6 +34,7 @@ BROWSER_CLIENT = os.path.join(_DIR, "browserClient.py")
 WAKE_WORDS  = ["hey jarvis", "jarvis", "hey jervis", "hey davis"]
 LAUNCH_COOLDOWN = 4.0
 HTTP_PORT   = 8766
+UPLOAD_STORE = UploadStore()
 
 # ── shared state (jarvis_web.html POSTs here; jarvis_visual.html polls here) ─
 _http_state      = {"state": "initializing", "text": "", "status": "INITIALIZING..."}
@@ -715,6 +722,31 @@ def start_http_server():
 
         def do_POST(self):
             global _url_slot
+            if self.path == "/api/uploads":
+                try:
+                    length = int(self.headers.get("Content-Length", 0))
+                    if length <= 0:
+                        raise UploadError("Upload request body is empty")
+                    if length > MAX_UPLOAD_REQUEST_BYTES:
+                        raise UploadError(
+                            f"Upload request exceeds the {MAX_UPLOAD_REQUEST_BYTES // (1024 * 1024)} MB limit"
+                        )
+                    body = self.rfile.read(length)
+                    uploads = parse_multipart_images(self.headers.get("Content-Type", ""), body)
+                    stored = [UPLOAD_STORE.save(upload) for upload in uploads]
+                    self.send_response(201)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"ok": True, "uploads": stored}).encode())
+                except (UploadError, ValueError) as e:
+                    self.send_response(400)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors()
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"ok": False, "error": str(e)}).encode())
+                return
+
             length = int(self.headers.get("Content-Length", 0))
             body   = self.rfile.read(length) if length else b""
 

--- a/test_browser_upload_action.py
+++ b/test_browser_upload_action.py
@@ -1,0 +1,62 @@
+import tempfile
+import unittest
+from unittest.mock import Mock
+
+from upload_store import (
+    PendingUpload,
+    UploadError,
+    UploadStore,
+    attach_uploaded_files,
+)
+
+
+class BrowserUploadActionTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.store = UploadStore(self.tmpdir.name)
+        self.page = Mock()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_input_file_resolves_tokens_and_consumes_them(self):
+        first = self.store.save(PendingUpload("first.png", "image/png", b"one"))
+        second = self.store.save(PendingUpload("second.jpg", "image/jpeg", b"two"))
+
+        count = attach_uploaded_files(
+            self.page,
+            self.store,
+            "input[type=file]",
+            [first["token"], second["token"]],
+            10000,
+        )
+
+        self.assertEqual(count, 2)
+        paths = self.page.set_input_files.call_args.args[1]
+        self.assertEqual([path.rsplit("/", 1)[-1] for path in paths], ["first.png", "second.jpg"])
+        for token in (first["token"], second["token"]):
+            with self.assertRaises(UploadError):
+                self.store.resolve(token)
+
+    def test_input_file_requires_upload_tokens(self):
+        with self.assertRaisesRegex(UploadError, "requires token"):
+            attach_uploaded_files(self.page, self.store, "input[type=file]", [], 10000)
+
+    def test_input_file_cleans_up_when_playwright_fails(self):
+        upload = self.store.save(PendingUpload("broken.png", "image/png", b"image"))
+        self.page.set_input_files.side_effect = RuntimeError("browser rejected file")
+
+        with self.assertRaisesRegex(RuntimeError, "browser rejected file"):
+            attach_uploaded_files(
+                self.page,
+                self.store,
+                "input[type=file]",
+                [upload["token"]],
+                10000,
+            )
+        with self.assertRaises(UploadError):
+            self.store.resolve(upload["token"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_upload_store.py
+++ b/test_upload_store.py
@@ -1,0 +1,98 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from upload_store import (
+    MAX_UPLOAD_BYTES,
+    PendingUpload,
+    UploadError,
+    UploadStore,
+    parse_multipart_images,
+)
+
+
+def multipart_body(boundary, files):
+    chunks = []
+    for field, filename, content_type, data in files:
+        chunks.extend(
+            [
+                f"--{boundary}\r\n".encode(),
+                (
+                    f'Content-Disposition: form-data; name="{field}"; filename="{filename}"\r\n'
+                ).encode(),
+                f"Content-Type: {content_type}\r\n\r\n".encode(),
+                data,
+                b"\r\n",
+            ]
+        )
+    chunks.append(f"--{boundary}--\r\n".encode())
+    return b"".join(chunks)
+
+
+class UploadStoreTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.store = UploadStore(self.tmpdir.name, ttl_seconds=60)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_parse_multiple_images(self):
+        boundary = "jarvis-test"
+        uploads = parse_multipart_images(
+            f"multipart/form-data; boundary={boundary}",
+            multipart_body(
+                boundary,
+                [
+                    ("files", "first.png", "image/png", b"png-data"),
+                    ("files", "second.jpg", "image/jpeg", b"jpeg-data"),
+                ],
+            ),
+        )
+
+        self.assertEqual([upload.filename for upload in uploads], ["first.png", "second.jpg"])
+        self.assertEqual(uploads[1].data, b"jpeg-data")
+
+    def test_parse_rejects_non_images_empty_files_and_oversized_files(self):
+        boundary = "jarvis-test"
+        cases = [
+            ("notes.txt", "text/plain", b"text"),
+            ("empty.png", "image/png", b""),
+            ("large.png", "image/png", b"x" * (MAX_UPLOAD_BYTES + 1)),
+        ]
+        for filename, content_type, data in cases:
+            with self.subTest(filename=filename), self.assertRaises(UploadError):
+                parse_multipart_images(
+                    f"multipart/form-data; boundary={boundary}",
+                    multipart_body(boundary, [("file", filename, content_type, data)]),
+                )
+
+    def test_save_uses_opaque_token_and_sanitizes_filename(self):
+        metadata = self.store.save(
+            PendingUpload("../../screenshot.png", "image/png", b"image"), now=100
+        )
+
+        path = self.store.resolve(metadata["token"], now=120)
+        self.assertEqual(path.name, "screenshot.png")
+        self.assertEqual(path.read_bytes(), b"image")
+        self.assertEqual(path.parent.parent, Path(self.tmpdir.name))
+
+    def test_resolve_rejects_invalid_and_expired_tokens(self):
+        with self.assertRaises(UploadError):
+            self.store.resolve("../../etc/passwd")
+
+        metadata = self.store.save(PendingUpload("old.png", "image/png", b"image"), now=100)
+        with self.assertRaises(UploadError):
+            self.store.resolve(metadata["token"], now=161)
+        self.assertFalse((Path(self.tmpdir.name) / metadata["token"]).exists())
+
+    def test_consume_removes_upload(self):
+        metadata = self.store.save(PendingUpload("once.png", "image/png", b"image"))
+        self.store.consume(metadata["token"])
+
+        with self.assertRaises(UploadError):
+            self.store.resolve(metadata["token"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/upload_store.py
+++ b/upload_store.py
@@ -1,0 +1,155 @@
+"""Temporary, token-addressed storage for browser file uploads."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from email.parser import BytesParser
+from email.policy import default
+from pathlib import Path
+
+
+MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+MAX_UPLOAD_REQUEST_BYTES = 25 * 1024 * 1024
+UPLOAD_TTL_SECONDS = 60 * 60
+
+
+class UploadError(ValueError):
+    """Raised when an upload cannot be accepted or resolved."""
+
+
+@dataclass(frozen=True)
+class PendingUpload:
+    filename: str
+    content_type: str
+    data: bytes
+
+
+def parse_multipart_images(content_type: str, body: bytes) -> list[PendingUpload]:
+    """Parse image file fields from a bounded multipart request body."""
+    if not content_type.lower().startswith("multipart/form-data"):
+        raise UploadError("Content-Type must be multipart/form-data")
+
+    message = BytesParser(policy=default).parsebytes(
+        b"Content-Type: " + content_type.encode("latin-1") + b"\r\n"
+        b"MIME-Version: 1.0\r\n\r\n" + body
+    )
+    if not message.is_multipart():
+        raise UploadError("Malformed multipart/form-data body")
+
+    uploads = []
+    for part in message.iter_parts():
+        if part.get_content_disposition() != "form-data":
+            continue
+        filename = part.get_filename()
+        if not filename:
+            continue
+        content_type = part.get_content_type().lower()
+        if not content_type.startswith("image/"):
+            raise UploadError(f"Unsupported file type for {filename!r}: {content_type}")
+        data = part.get_payload(decode=True) or b""
+        if not data:
+            raise UploadError(f"Uploaded file {filename!r} is empty")
+        if len(data) > MAX_UPLOAD_BYTES:
+            raise UploadError(
+                f"Uploaded file {filename!r} exceeds the {MAX_UPLOAD_BYTES // (1024 * 1024)} MB limit"
+            )
+        uploads.append(PendingUpload(filename, content_type, data))
+
+    if not uploads:
+        raise UploadError("No image files were included in the request")
+    return uploads
+
+
+class UploadStore:
+    """Store uploads under opaque UUID tokens shared by launcher and browser client."""
+
+    def __init__(self, root: str | os.PathLike[str] | None = None, ttl_seconds: int = UPLOAD_TTL_SECONDS):
+        configured_root = root or os.environ.get("JARVIS_UPLOAD_DIR")
+        self.root = Path(configured_root or Path(tempfile.gettempdir()) / "jarvis_uploads")
+        self.ttl_seconds = ttl_seconds
+
+    def save(self, upload: PendingUpload, now: float | None = None) -> dict:
+        self.cleanup_expired(now=now)
+        token = str(uuid.uuid4())
+        directory = self.root / token
+        directory.mkdir(parents=True, exist_ok=False)
+        filename = Path(upload.filename).name or "upload"
+        path = directory / filename
+        path.write_bytes(upload.data)
+        created_at = time.time() if now is None else now
+        metadata = {
+            "token": token,
+            "filename": filename,
+            "content_type": upload.content_type,
+            "size": len(upload.data),
+            "created_at": created_at,
+        }
+        (directory / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+        return metadata
+
+    def resolve(self, token: str, now: float | None = None) -> Path:
+        token = str(token).strip()
+        try:
+            normalized = str(uuid.UUID(token))
+        except (ValueError, AttributeError) as exc:
+            raise UploadError("Invalid upload token") from exc
+        if normalized != token.lower():
+            raise UploadError("Invalid upload token")
+
+        directory = self.root / normalized
+        metadata_path = directory / "metadata.json"
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+            raise UploadError("Upload token was not found or has expired") from exc
+
+        current_time = time.time() if now is None else now
+        if current_time - float(metadata["created_at"]) > self.ttl_seconds:
+            shutil.rmtree(directory, ignore_errors=True)
+            raise UploadError("Upload token was not found or has expired")
+
+        path = directory / metadata["filename"]
+        if not path.is_file():
+            raise UploadError("Uploaded file is no longer available")
+        return path
+
+    def consume(self, token: str) -> None:
+        try:
+            normalized = str(uuid.UUID(str(token).strip()))
+        except (ValueError, AttributeError):
+            return
+        shutil.rmtree(self.root / normalized, ignore_errors=True)
+
+    def cleanup_expired(self, now: float | None = None) -> None:
+        if not self.root.exists():
+            return
+        current_time = time.time() if now is None else now
+        for directory in self.root.iterdir():
+            if not directory.is_dir():
+                continue
+            try:
+                metadata = json.loads((directory / "metadata.json").read_text(encoding="utf-8"))
+                expired = current_time - float(metadata["created_at"]) > self.ttl_seconds
+            except (FileNotFoundError, json.JSONDecodeError, KeyError, TypeError, ValueError, OSError):
+                expired = True
+            if expired:
+                shutil.rmtree(directory, ignore_errors=True)
+
+
+def attach_uploaded_files(page, store: UploadStore, selector: str, tokens: list[str], timeout: int) -> int:
+    """Resolve upload tokens, attach their files, and remove them after the attempt."""
+    if not isinstance(tokens, list) or not tokens:
+        raise UploadError("input_file requires token or a non-empty tokens list")
+    paths = [str(store.resolve(token)) for token in tokens]
+    try:
+        page.set_input_files(selector, paths, timeout=timeout)
+    finally:
+        for token in tokens:
+            store.consume(token)
+    return len(paths)


### PR DESCRIPTION
Closes #6

## What changed

- adds a bounded `multipart/form-data` endpoint at `POST /api/uploads` for one or more images
- stores uploads under opaque UUID tokens in the system temporary directory
- supports `input_file` and `set_input_files` WebSocket actions with either `token` or `tokens`
- removes temporary files after the Playwright attempt and expires abandoned uploads after one hour
- documents the request/action flow and size limits

The API intentionally does not return or accept server filesystem paths. This keeps remote browser commands from selecting arbitrary local files. Requests are capped at 25 MB, individual images at 10 MB, and non-image multipart fields are rejected.

## Verification

- `python3 -m unittest discover -v` (17 passed)
- `python3 -m compileall -q .`
- `git diff --check`
- live localhost smoke test: multipart upload returned HTTP 201, the token resolved to the expected bytes, and cleanup removed it

Tested on macOS with Python 3.9.6. The upload/parser/store/action tests are dependency-free and cover multiple files, path sanitization, invalid and expired tokens, size/type validation, successful cleanup, and cleanup when Playwright rejects the file.

## Reward points

This is my first contribution and addresses an approved `priority: high` / `reward eligible` issue. I would appreciate the medium-feature award (250 base points), with any test/documentation points or multipliers left to maintainer discretion.