### PR TITLE
ci: add cross-platform packaging workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,40 @@
+name: Package Toingg Jarvis
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  package:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: python -m pip install -r requirements-build.txt
+
+      - name: Install Playwright browser
+        run: python -m playwright install chromium
+
+      - name: Build PyInstaller bundle
+        run: pyinstaller --clean --noconfirm jarvis_launcher.spec
+
+      - name: Stage release artifact
+        run: python scripts/package_release.py --frozen-dist dist/toingg-jarvis --output artifacts
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: toingg-jarvis-${{ runner.os }}
+          path: artifacts/*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!jarvis_launcher.spec
 
 # Installer logs
 pip-log.txt

--- a/demo/bounty-13-packaging-demo.md
+++ b/demo/bounty-13-packaging-demo.md
@@ -1,0 +1,19 @@
+# Bounty #13 Packaging Demo
+
+This PR adds the release path expected by the bounty:
+
+```bash
+python -m pip install -r requirements-build.txt
+python -m playwright install chromium
+pyinstaller --clean --noconfirm jarvis_launcher.spec
+python scripts/package_release.py --frozen-dist dist/toingg-jarvis --output artifacts
+```
+
+Expected output:
+
+```text
+artifacts/
+└── toingg-jarvis-<platform>-<arch>.zip
+```
+
+The GitHub Actions workflow runs the same steps on Windows, macOS, and Linux and uploads the zip artifacts for each platform.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -1,0 +1,35 @@
+# Packaging Toingg Jarvis
+
+This repo can produce Windows, Linux, and macOS release artifacts with PyInstaller.
+
+## Local Build
+
+```bash
+python -m pip install -r requirements-build.txt
+python -m playwright install chromium
+pyinstaller --clean --noconfirm jarvis_launcher.spec
+python scripts/package_release.py --frozen-dist dist/toingg-jarvis --output artifacts
+```
+
+The final archive is written to `artifacts/toingg-jarvis-<platform>-<arch>.zip`.
+
+## GitHub Actions
+
+The `Package Toingg Jarvis` workflow runs on tags matching `v*` and by manual dispatch. It builds a PyInstaller bundle on:
+
+- `ubuntu-latest`
+- `macos-latest`
+- `windows-latest`
+
+Each run uploads one platform zip artifact.
+
+## Artifact Layout
+
+Each zip contains:
+
+- a `toingg-jarvis/` PyInstaller bundle when the build produced one
+- source fallback files for local debugging
+- `run-toingg-jarvis.sh` or `run-toingg-jarvis.bat`
+- `RELEASE_NOTES.txt`
+
+The launcher prefers the frozen bundle and falls back to `python jarvis_launcher.py` if needed.

--- a/jarvis_launcher.spec
+++ b/jarvis_launcher.spec
@@ -1,0 +1,66 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from pathlib import Path
+
+
+ROOT = Path.cwd()
+DATA_FILES = [
+    ("browserClient.py", "."),
+    ("jarvis_web.html", "."),
+    ("jarvis_visual.html", "."),
+    ("native_file_manager.py", "."),
+    ("pipecat_gemini_tools.py", "."),
+    ("config.example.json", "."),
+    ("README.md", "."),
+    ("JARVIS_README.md", "."),
+    ("NATIVE_FILE_MANAGER.md", "."),
+    ("PIPECAT_GEMINI_TOOLS.md", "."),
+]
+
+
+a = Analysis(
+    ["jarvis_launcher.py"],
+    pathex=[str(ROOT)],
+    binaries=[],
+    datas=[(str(ROOT / src), dest) for src, dest in DATA_FILES if (ROOT / src).exists()],
+    hiddenimports=[
+        "websocket",
+        "speech_recognition",
+        "playwright",
+        "playwright.sync_api",
+        "playwright_stealth",
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="toingg-jarvis",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="toingg-jarvis",
+)

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pyinstaller>=6.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy>=1.24
+playwright>=1.44
+playwright-stealth>=1.0
+SpeechRecognition>=3.10
+websocket-client>=1.7

--- a/scripts/package_release.py
+++ b/scripts/package_release.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Stage a portable Toingg Jarvis release artifact for the current platform."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shutil
+import stat
+import zipfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_FILES = [
+    "README.md",
+    "JARVIS_README.md",
+    "NATIVE_FILE_MANAGER.md",
+    "PIPECAT_GEMINI_TOOLS.md",
+    "config.example.json",
+    "jarvis_web.html",
+    "jarvis_visual.html",
+    "browserClient.py",
+    "jarvis_launcher.py",
+    "native_file_manager.py",
+    "pipecat_gemini_tools.py",
+]
+
+
+def copy_tree(src: Path, dst: Path) -> None:
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst)
+
+
+def copy_sources(dst: Path) -> None:
+    for name in SOURCE_FILES:
+        src = ROOT / name
+        if src.exists():
+            shutil.copy2(src, dst / name)
+
+
+def write_launcher(dst: Path, system: str) -> None:
+    if system == "Windows":
+        launcher = dst / "run-toingg-jarvis.bat"
+        launcher.write_text(
+            "@echo off\r\n"
+            "cd /d \"%~dp0\"\r\n"
+            "if exist toingg-jarvis\\toingg-jarvis.exe (\r\n"
+            "  toingg-jarvis\\toingg-jarvis.exe\r\n"
+            ") else (\r\n"
+            "  python jarvis_launcher.py\r\n"
+            ")\r\n",
+            encoding="utf-8",
+        )
+        return
+
+    launcher = dst / "run-toingg-jarvis.sh"
+    launcher.write_text(
+        "#!/usr/bin/env sh\n"
+        "set -eu\n"
+        "cd \"$(dirname \"$0\")\"\n"
+        "if [ -x \"./toingg-jarvis/toingg-jarvis\" ]; then\n"
+        "  exec ./toingg-jarvis/toingg-jarvis\n"
+        "fi\n"
+        "exec python3 jarvis_launcher.py\n",
+        encoding="utf-8",
+    )
+    launcher.chmod(launcher.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def write_release_notes(dst: Path, system: str, machine: str) -> None:
+    (dst / "RELEASE_NOTES.txt").write_text(
+        "Toingg Jarvis packaged artifact\n"
+        f"Platform: {system} {machine}\n\n"
+        "Run the platform launcher in this folder. If the PyInstaller bundle is present, "
+        "the launcher uses it; otherwise it falls back to the source launcher.\n\n"
+        "First run may still require Playwright browser installation on systems where "
+        "Chromium is not already cached.\n",
+        encoding="utf-8",
+    )
+
+
+def make_zip(src: Path, zip_path: Path) -> None:
+    if zip_path.exists():
+        zip_path.unlink()
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(src.rglob("*")):
+            archive.write(path, path.relative_to(src.parent))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--frozen-dist", default="dist/toingg-jarvis")
+    parser.add_argument("--output", default="artifacts")
+    args = parser.parse_args()
+
+    system = platform.system() or "unknown"
+    machine = platform.machine() or "unknown"
+    artifact_name = f"toingg-jarvis-{system.lower()}-{machine.lower()}"
+    output_dir = ROOT / args.output
+    stage_dir = output_dir / artifact_name
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if stage_dir.exists():
+        shutil.rmtree(stage_dir)
+    stage_dir.mkdir(parents=True)
+
+    frozen_dist = ROOT / args.frozen_dist
+    if frozen_dist.exists():
+        copy_tree(frozen_dist, stage_dir / "toingg-jarvis")
+
+    copy_sources(stage_dir)
+    write_launcher(stage_dir, system)
+    write_release_notes(stage_dir, system, machine)
+    make_zip(stage_dir, output_dir / f"{artifact_name}.zip")
+
+    print(f"Created {output_dir / f'{artifact_name}.zip'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

/claim #13

Adds a focused cross-platform packaging path for Toingg Jarvis without changing runtime behavior:

- runtime and build dependency manifests
- PyInstaller spec for the `jarvis_launcher.py` bundle
- local artifact staging script that creates `toingg-jarvis-<platform>-<arch>.zip`
- GitHub Actions matrix for Windows, macOS, and Linux package artifacts
- packaging docs plus a concise demo command transcript in `demo/bounty-13-packaging-demo.md`
- narrow `.gitignore` exception so the project PyInstaller spec is reviewable

## Validation

- `/usr/bin/python3.11 -m py_compile scripts/package_release.py`
- `/usr/bin/python3.11 scripts/package_release.py --frozen-dist dist/toingg-jarvis --output artifacts-test`
- `unzip -l artifacts-test/*.zip` confirmed the staged release archive includes launcher/source/docs assets
- `/usr/bin/python3.11 -m unittest test_pipecat_gemini_tools.py test_scheduled_actions.py test_native_file_manager.py -v` (17 tests passing)
- `git diff --check`

Note: I could not create a real video file in this environment because no local video encoder is installed, so I included a reproducible demo transcript under `demo/` instead.