### PR TITLE
Add verified native installers for Windows, Linux, and macOS

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -73,7 +73,15 @@ jobs:
         run: python -m unittest discover -v
 
       - name: Build standalone application
+        if: runner.os != 'macOS'
         run: pyinstaller jarvis.spec --clean --noconfirm
+
+      - name: Build standalone macOS application
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          chmod +x packaging/macos/build_standalone.sh
+          packaging/macos/build_standalone.sh
 
       - name: Smoke-test Windows application
         if: runner.os == 'Windows'
@@ -92,7 +100,7 @@ jobs:
         if: runner.os == 'macOS'
         env:
           JARVIS_CONFIG_DIR: ${{ runner.temp }}/jarvis-smoke-config
-        run: ./dist/JARVIS.app/Contents/MacOS/JARVIS --packaging-smoke-test
+        run: ./dist/JARVIS/JARVIS --packaging-smoke-test
 
       - name: Create Windows installer
         if: runner.os == 'Windows'
@@ -101,7 +109,14 @@ jobs:
           $version = $env:RELEASE_VERSION -replace '^v', ''
           $source = (Resolve-Path 'dist\JARVIS').Path
           $output = New-Item -ItemType Directory -Force 'artifacts'
-          & makensis.exe "/DAPP_VERSION=$version" "/DSOURCE_DIR=$source" "/DOUTPUT_DIR=$($output.FullName)" 'packaging\windows\JARVIS.nsi'
+          $makensis = Join-Path ${env:ProgramFiles(x86)} 'NSIS\makensis.exe'
+          if (-not (Test-Path $makensis)) {
+            $makensis = Join-Path $env:ProgramFiles 'NSIS\makensis.exe'
+          }
+          if (-not (Test-Path $makensis)) {
+            throw 'makensis.exe was not found after the NSIS installation step'
+          }
+          & $makensis "/DAPP_VERSION=$version" "/DSOURCE_DIR=$source" "/DOUTPUT_DIR=$($output.FullName)" 'packaging\windows\JARVIS.nsi'
           Compress-Archive -Path 'dist\JARVIS\*' -DestinationPath "artifacts\JARVIS-$version-windows-x64-portable.zip"
 
       - name: Create Linux packages
@@ -114,14 +129,14 @@ jobs:
           packaging/linux/build_deb.sh dist/JARVIS "$version" artifacts
           tar -C dist/JARVIS -czf "artifacts/JARVIS-${version}-linux-portable.tar.gz" .
 
-      - name: Create macOS disk image
+      - name: Create macOS app bundle and disk image
         if: runner.os == 'macOS'
         shell: bash
         run: |
           version=${RELEASE_VERSION#v}
           mkdir -p artifacts
           chmod +x packaging/macos/build_dmg.sh
-          packaging/macos/build_dmg.sh dist/JARVIS.app "$version" artifacts
+          packaging/macos/build_dmg.sh dist/JARVIS "$version" artifacts
 
       - name: Upload native artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -1,0 +1,153 @@
+name: Native release
+
+on:
+  pull_request:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (for example v1.2.3)"
+        required: true
+        default: "v0.1.0"
+
+permissions:
+  contents: read
+
+env:
+  RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.0.0-ci' }}
+  PLAYWRIGHT_BROWSERS_PATH: "0"
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: Windows
+            os: windows-latest
+          - platform: Linux
+            os: ubuntu-latest
+          - platform: macOS
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-packaging.txt
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev libportaudio2 portaudio19-dev
+
+      - name: Install macOS build dependencies
+        if: runner.os == 'macOS'
+        run: brew install portaudio
+
+      - name: Install Windows installer tooling
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: choco install nsis --yes --no-progress
+
+      - name: Install Python and browser dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-packaging.txt
+          if [[ "${RUNNER_OS}" == "Linux" ]]; then
+            python -m playwright install --with-deps --no-shell chromium
+          else
+            python -m playwright install --no-shell chromium
+          fi
+
+      - name: Run tests
+        run: python -m unittest discover -v
+
+      - name: Build standalone application
+        run: pyinstaller jarvis.spec --clean --noconfirm
+
+      - name: Smoke-test Windows application
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          JARVIS_CONFIG_DIR: ${{ runner.temp }}\jarvis-smoke-config
+        run: .\dist\JARVIS\JARVIS.exe --packaging-smoke-test
+
+      - name: Smoke-test Linux application
+        if: runner.os == 'Linux'
+        env:
+          JARVIS_CONFIG_DIR: ${{ runner.temp }}/jarvis-smoke-config
+        run: ./dist/JARVIS/JARVIS --packaging-smoke-test
+
+      - name: Smoke-test macOS application
+        if: runner.os == 'macOS'
+        env:
+          JARVIS_CONFIG_DIR: ${{ runner.temp }}/jarvis-smoke-config
+        run: ./dist/JARVIS.app/Contents/MacOS/JARVIS --packaging-smoke-test
+
+      - name: Create Windows installer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $version = $env:RELEASE_VERSION -replace '^v', ''
+          $source = (Resolve-Path 'dist\JARVIS').Path
+          $output = New-Item -ItemType Directory -Force 'artifacts'
+          & makensis.exe "/DAPP_VERSION=$version" "/DSOURCE_DIR=$source" "/DOUTPUT_DIR=$($output.FullName)" 'packaging\windows\JARVIS.nsi'
+          Compress-Archive -Path 'dist\JARVIS\*' -DestinationPath "artifacts\JARVIS-$version-windows-x64-portable.zip"
+
+      - name: Create Linux packages
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          version=${RELEASE_VERSION#v}
+          mkdir -p artifacts
+          chmod +x packaging/linux/build_deb.sh
+          packaging/linux/build_deb.sh dist/JARVIS "$version" artifacts
+          tar -C dist/JARVIS -czf "artifacts/JARVIS-${version}-linux-portable.tar.gz" .
+
+      - name: Create macOS disk image
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          version=${RELEASE_VERSION#v}
+          mkdir -p artifacts
+          chmod +x packaging/macos/build_dmg.sh
+          packaging/macos/build_dmg.sh dist/JARVIS.app "$version" artifacts
+
+      - name: Upload native artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: JARVIS-${{ matrix.platform }}
+          path: artifacts/*
+          if-no-files-found: error
+          retention-days: 14
+
+  release:
+    name: Publish GitHub release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Publish native installers
+        uses: softprops/action-gh-release@v2
+        with:
+          name: JARVIS ${{ env.RELEASE_VERSION }}
+          generate_release_notes: true
+          files: artifacts/*
+          fail_on_unmatched_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!jarvis.spec
 
 # Installer logs
 pip-log.txt
@@ -142,6 +143,9 @@ celerybeat.pid
 .env
 .envrc
 .venv
+.venv*/
+.tools/
+artifacts/
 env/
 venv/
 ENV/

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,0 +1,66 @@
+# Native packaging
+
+JARVIS ships a single PyInstaller application and wraps it in native installers:
+
+| Platform | Installer | Portable artifact |
+| --- | --- | --- |
+| Windows x64 | NSIS `.exe` | `.zip` |
+| Debian/Ubuntu | `.deb` | `.tar.gz` |
+| macOS | `.dmg` containing `JARVIS.app` | app bundle inside the DMG |
+
+The application includes Python, its runtime packages, and Playwright Chromium.
+The build does not download Python packages or browser binaries at first launch.
+
+## Automated release
+
+The `Native release` workflow runs unit tests and an executable smoke test on
+Windows, Ubuntu, and macOS before it uploads artifacts. Pushing a tag matching
+`v*` also creates a GitHub Release containing all native installers. A manual
+workflow run builds the same artifacts without publishing a release.
+
+## Local Windows build
+
+```powershell
+python -m pip install -r requirements-packaging.txt
+$env:PLAYWRIGHT_BROWSERS_PATH = "0"
+python -m playwright install --no-shell chromium
+pyinstaller jarvis.spec --clean --noconfirm
+$env:JARVIS_CONFIG_DIR = "$env:TEMP\jarvis-smoke"
+.\dist\JARVIS\JARVIS.exe --packaging-smoke-test
+makensis.exe /DAPP_VERSION=0.1.0 /DSOURCE_DIR="$PWD\dist\JARVIS" /DOUTPUT_DIR="$PWD\artifacts" packaging\windows\JARVIS.nsi
+```
+
+## Local Linux build
+
+```bash
+sudo apt-get install -y dpkg-dev libportaudio2 portaudio19-dev
+python -m pip install -r requirements-packaging.txt
+PLAYWRIGHT_BROWSERS_PATH=0 python -m playwright install --with-deps --no-shell chromium
+PLAYWRIGHT_BROWSERS_PATH=0 pyinstaller jarvis.spec --clean --noconfirm
+JARVIS_CONFIG_DIR=/tmp/jarvis-smoke ./dist/JARVIS/JARVIS --packaging-smoke-test
+packaging/linux/build_deb.sh dist/JARVIS 0.1.0 artifacts
+```
+
+## Local macOS build
+
+```bash
+brew install portaudio
+python -m pip install -r requirements-packaging.txt
+PLAYWRIGHT_BROWSERS_PATH=0 python -m playwright install --no-shell chromium
+PLAYWRIGHT_BROWSERS_PATH=0 pyinstaller jarvis.spec --clean --noconfirm
+JARVIS_CONFIG_DIR=/tmp/jarvis-smoke ./dist/JARVIS.app/Contents/MacOS/JARVIS --packaging-smoke-test
+packaging/macos/build_dmg.sh dist/JARVIS.app 0.1.0 artifacts
+```
+
+## Runtime data
+
+Install directories are treated as read-only. Credentials and the persistent
+browser profile live in the current user's configuration directory:
+
+- Windows: `%APPDATA%\JARVIS`
+- macOS: `~/Library/Application Support/JARVIS`
+- Linux: `${XDG_CONFIG_HOME:-~/.config}/jarvis`
+
+`JARVIS_CONFIG_DIR` overrides this location for automation and smoke testing.
+Uninstalling JARVIS intentionally leaves user credentials and browser state in
+place so an upgrade or reinstall does not erase them.

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -47,9 +47,9 @@ packaging/linux/build_deb.sh dist/JARVIS 0.1.0 artifacts
 brew install portaudio
 python -m pip install -r requirements-packaging.txt
 PLAYWRIGHT_BROWSERS_PATH=0 python -m playwright install --no-shell chromium
-PLAYWRIGHT_BROWSERS_PATH=0 pyinstaller jarvis.spec --clean --noconfirm
-JARVIS_CONFIG_DIR=/tmp/jarvis-smoke ./dist/JARVIS.app/Contents/MacOS/JARVIS --packaging-smoke-test
-packaging/macos/build_dmg.sh dist/JARVIS.app 0.1.0 artifacts
+packaging/macos/build_standalone.sh
+JARVIS_CONFIG_DIR=/tmp/jarvis-smoke ./dist/JARVIS/JARVIS --packaging-smoke-test
+packaging/macos/build_dmg.sh dist/JARVIS 0.1.0 artifacts
 ```
 
 ## Runtime data

--- a/README.md
+++ b/README.md
@@ -204,6 +204,13 @@ python3 jarvis_launcher.py
 
 ## 🛠️ Installation
 
+### Native installers
+
+Tagged releases build standalone installers for Windows (`.exe`), Debian/Ubuntu
+(`.deb`), and macOS (`.dmg`). Python is bundled, so end users do not need to
+install it separately. See [PACKAGING.md](PACKAGING.md) for the artifact layout,
+local build commands, and release verification.
+
 ### 1. Clone the repository
 
 ```bash

--- a/jarvis.spec
+++ b/jarvis.spec
@@ -1,0 +1,91 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_all
+
+
+ROOT = Path(SPECPATH)
+
+playwright_datas, playwright_binaries, playwright_hiddenimports = collect_all(
+    "playwright"
+)
+stealth_datas, stealth_binaries, stealth_hiddenimports = collect_all(
+    "playwright_stealth"
+)
+
+datas = [
+    (str(ROOT / "jarvis_web.html"), "."),
+    (str(ROOT / "jarvis_visual.html"), "."),
+    (str(ROOT / "config.example.json"), "."),
+    (str(ROOT / "LICENSE"), "."),
+    (str(ROOT / "README.md"), "."),
+] + playwright_datas + stealth_datas
+
+hiddenimports = [
+    "browserClient",
+    "native_file_manager",
+    "numpy",
+    "pyaudio",
+    "speech_recognition",
+    "websocket",
+    "playwright.sync_api",
+    "playwright_stealth",
+] + playwright_hiddenimports + stealth_hiddenimports
+
+analysis = Analysis(
+    [str(ROOT / "jarvis_launcher.py")],
+    pathex=[str(ROOT)],
+    binaries=playwright_binaries + stealth_binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=1,
+)
+
+pyz = PYZ(analysis.pure)
+
+exe = EXE(
+    pyz,
+    analysis.scripts,
+    [],
+    exclude_binaries=True,
+    name="JARVIS",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+collection = COLLECT(
+    exe,
+    analysis.binaries,
+    analysis.datas,
+    strip=False,
+    upx=False,
+    name="JARVIS",
+)
+
+if sys.platform == "darwin":
+    app = BUNDLE(
+        collection,
+        name="JARVIS.app",
+        bundle_identifier="com.pgagi.jarvis",
+        info_plist={
+            "CFBundleDisplayName": "JARVIS",
+            "NSMicrophoneUsageDescription": (
+                "JARVIS uses the microphone to listen for the wake word and voice commands."
+            ),
+        },
+    )

--- a/jarvis.spec
+++ b/jarvis.spec
@@ -1,6 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-import sys
 from pathlib import Path
 
 from PyInstaller.utils.hooks import collect_all
@@ -76,16 +75,3 @@ collection = COLLECT(
     upx=False,
     name="JARVIS",
 )
-
-if sys.platform == "darwin":
-    app = BUNDLE(
-        collection,
-        name="JARVIS.app",
-        bundle_identifier="com.pgagi.jarvis",
-        info_plist={
-            "CFBundleDisplayName": "JARVIS",
-            "NSMicrophoneUsageDescription": (
-                "JARVIS uses the microphone to listen for the wake word and voice commands."
-            ),
-        },
-    )

--- a/jarvis_launcher.py
+++ b/jarvis_launcher.py
@@ -21,13 +21,70 @@ from datetime import datetime, timedelta, timezone
 from native_file_manager import NativeFileActionError, handle_file_action_payload
 
 # ── CONFIG ────────────────────────────────────────────────────────────────────
-_DIR        = os.path.dirname(os.path.abspath(__file__))
-WEB_HTML    = os.path.join(_DIR, "jarvis_web.html")
-VISUAL_HTML = os.path.join(_DIR, "jarvis_visual.html")
-BROWSER_CLIENT = os.path.join(_DIR, "browserClient.py")
+_SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
+_BUNDLE_DIR = getattr(sys, "_MEIPASS", _SOURCE_DIR)
+
+# Playwright stores browsers beside its driver when installed with
+# PLAYWRIGHT_BROWSERS_PATH=0. Point frozen builds at that bundled location.
+if getattr(sys, "frozen", False):
+    os.environ.setdefault("PLAYWRIGHT_BROWSERS_PATH", "0")
+
+
+def _resource_path(name):
+    """Return a read-only resource path in source and PyInstaller builds."""
+    return os.path.join(_BUNDLE_DIR, name)
+
+
+def _platform_config_dir():
+    """Return a writable per-user directory without touching the install tree."""
+    override = os.environ.get("JARVIS_CONFIG_DIR")
+    if override:
+        return os.path.abspath(os.path.expanduser(override))
+
+    system = _plat.system()
+    if system == "Windows":
+        root = os.environ.get("APPDATA") or os.path.expanduser("~")
+        return os.path.join(root, "JARVIS")
+    if system == "Darwin":
+        return os.path.expanduser("~/Library/Application Support/JARVIS")
+
+    root = os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config")
+    return os.path.join(root, "jarvis")
+
+
+def _runtime_config_dir():
+    """Keep source checkouts compatible while packaged apps use user storage."""
+    if not os.environ.get("JARVIS_CONFIG_DIR") and not getattr(sys, "frozen", False):
+        legacy_config = os.path.join(_SOURCE_DIR, "config.json")
+        if os.path.isfile(legacy_config):
+            return _SOURCE_DIR
+    return _platform_config_dir()
+
+
+_CONFIG_DIR = _runtime_config_dir()
+CONFIG_PATH = os.path.join(_CONFIG_DIR, "config.json")
+BROWSER_PROFILE_DIR = os.path.join(_CONFIG_DIR, "browser-profile")
+WEB_HTML = _resource_path("jarvis_web.html")
+VISUAL_HTML = _resource_path("jarvis_visual.html")
+BROWSER_CLIENT = _resource_path("browserClient.py")
 WAKE_WORDS  = ["hey jarvis", "jarvis", "hey jervis", "hey davis"]
 LAUNCH_COOLDOWN = 4.0
 HTTP_PORT   = 8766
+
+
+def _ensure_config_file():
+    """Create the user's config from the bundled example when necessary."""
+    os.makedirs(_CONFIG_DIR, exist_ok=True)
+    if not os.path.exists(CONFIG_PATH):
+        example_path = _resource_path("config.example.json")
+        try:
+            with open(example_path, "r", encoding="utf-8") as source:
+                initial_config = json.load(source)
+        except (OSError, ValueError):
+            initial_config = {}
+        with open(CONFIG_PATH, "w", encoding="utf-8") as target:
+            json.dump(initial_config, target, indent=2)
+    return CONFIG_PATH
 
 # ── shared state (jarvis_web.html POSTs here; jarvis_visual.html polls here) ─
 _http_state      = {"state": "initializing", "text": "", "status": "INITIALIZING..."}
@@ -627,11 +684,26 @@ def start_browser_client():
     global _browser_client_proc
     if _browser_client_proc and _browser_client_proc.poll() is None:
         print("  [browser] already running"); return
-    if not os.path.exists(BROWSER_CLIENT):
+    if not getattr(sys, "frozen", False) and not os.path.exists(BROWSER_CLIENT):
         print("  [browser] ⚠  browserClient.py not found"); return
 
     try:
-        _browser_client_proc = subprocess.Popen([sys.executable, BROWSER_CLIENT], cwd=_DIR)
+        os.makedirs(_CONFIG_DIR, exist_ok=True)
+        if getattr(sys, "frozen", False):
+            args = [
+                sys.executable,
+                "--browser-client",
+                "--user-data-dir",
+                BROWSER_PROFILE_DIR,
+            ]
+        else:
+            args = [
+                sys.executable,
+                BROWSER_CLIENT,
+                "--user-data-dir",
+                BROWSER_PROFILE_DIR,
+            ]
+        _browser_client_proc = subprocess.Popen(args, cwd=_CONFIG_DIR)
         print("  [browser] ✅ browserClient.py started")
     except Exception as e:
         print(f"  [browser] ⚠  Failed to start browserClient.py: {e}")
@@ -770,7 +842,8 @@ def start_http_server():
             elif self.path in ("/visual", "/visual.html"):
                 self._serve_file(VISUAL_HTML)
             elif self.path == "/config.json":
-                self._serve_file(os.path.join(_DIR, "config.json"), "application/json")
+                _ensure_config_file()
+                self._serve_file(CONFIG_PATH, "application/json")
             elif self.path == "/state":
                 with _http_state_lock:
                     data = json.dumps(_http_state).encode()
@@ -957,7 +1030,7 @@ def start_http_server():
                     token = payload.get("token", "").strip()
                     if not token:
                         raise ValueError("token is empty")
-                    cfg_path = os.path.join(_DIR, "config.json")
+                    cfg_path = _ensure_config_file()
                     try:
                         with open(cfg_path, "r") as f:
                             cfg = json.load(f)
@@ -1219,7 +1292,7 @@ def _is_valid_token(token):
     return len(token) >= 20 and token.lower() not in _PLACEHOLDER_TOKENS
 
 def _load_token():
-    cfg_path = os.path.join(_DIR, "config.json")
+    cfg_path = _ensure_config_file()
     try:
         with open(cfg_path, "r") as f:
             return json.load(f).get("TOKEN", "").strip()
@@ -1227,7 +1300,7 @@ def _load_token():
         return ""
 
 def _save_token(token):
-    cfg_path = os.path.join(_DIR, "config.json")
+    cfg_path = _ensure_config_file()
     try:
         with open(cfg_path, "r") as f:
             cfg = json.load(f)
@@ -1323,6 +1396,33 @@ def check_api_key():
             print("  ⚠   Invalid choice. Enter 1, 2, 3, Q, or paste your API key.\n", flush=True)
 
 # ── MAIN ──────────────────────────────────────────────────────────────────────
+def packaging_smoke_test():
+    """Verify that a packaged build has its resources and writable config."""
+    required_resources = [WEB_HTML, VISUAL_HTML, _resource_path("config.example.json")]
+    missing = [path for path in required_resources if not os.path.isfile(path)]
+    if missing:
+        print("Missing packaged resources: " + ", ".join(missing), file=sys.stderr)
+        return 1
+
+    try:
+        config_path = _ensure_config_file()
+        with open(config_path, "r", encoding="utf-8") as config_file:
+            json.load(config_file)
+        import browserClient  # noqa: F401 - proves the bundled automation module imports
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as playwright:
+            browser_path = playwright.chromium.executable_path
+        if not os.path.isfile(browser_path):
+            raise FileNotFoundError(f"bundled Chromium not found: {browser_path}")
+    except Exception as exc:
+        print(f"Packaging smoke test failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Packaging smoke test passed; config={config_path}; chromium={browser_path}")
+    return 0
+
+
 def main():
     print("""
   ╔══════════════════════════════════════════╗
@@ -1357,4 +1457,12 @@ def main():
         print("\n  Stopped.")
 
 if __name__ == "__main__":
-    main()
+    if "--browser-client" in sys.argv:
+        sys.argv.remove("--browser-client")
+        import browserClient
+
+        browserClient.main()
+    elif "--packaging-smoke-test" in sys.argv:
+        sys.exit(packaging_smoke_test())
+    else:
+        main()

--- a/packaging/linux/build_deb.sh
+++ b/packaging/linux/build_deb.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <pyinstaller-dir> <version> <output-dir>" >&2
+  exit 2
+fi
+
+source_dir=$(realpath "$1")
+version=${2#v}
+output_dir=$(realpath -m "$3")
+
+if [[ ! -x "$source_dir/JARVIS" ]]; then
+  echo "missing executable: $source_dir/JARVIS" >&2
+  exit 1
+fi
+if [[ ! "$version" =~ ^[0-9][0-9A-Za-z.+:~-]*$ ]]; then
+  echo "invalid Debian version: $version" >&2
+  exit 1
+fi
+
+architecture=$(dpkg --print-architecture)
+work_dir=$(mktemp -d)
+trap 'rm -rf -- "$work_dir"' EXIT
+
+package_root="$work_dir/jarvis"
+install_dir="$package_root/opt/jarvis"
+mkdir -p "$install_dir" "$package_root/usr/bin" \
+  "$package_root/usr/share/applications" "$package_root/DEBIAN" "$output_dir"
+cp -a "$source_dir/." "$install_dir/"
+
+cat > "$package_root/usr/bin/jarvis" <<'EOF'
+#!/usr/bin/env sh
+exec /opt/jarvis/JARVIS "$@"
+EOF
+chmod 0755 "$package_root/usr/bin/jarvis"
+
+cat > "$package_root/usr/share/applications/jarvis.desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=JARVIS
+Comment=Voice-enabled personal assistant
+Exec=/opt/jarvis/JARVIS
+Terminal=true
+Categories=Utility;
+EOF
+
+cat > "$package_root/DEBIAN/control" <<EOF
+Package: jarvis
+Version: $version
+Section: utils
+Priority: optional
+Architecture: $architecture
+Maintainer: PG-AGI <noreply@github.com>
+Depends: libportaudio2
+Description: Cross-platform JARVIS voice assistant
+ A standalone desktop package for the Toingg-powered JARVIS assistant.
+EOF
+
+artifact="$output_dir/JARVIS-${version}-linux-${architecture}.deb"
+dpkg-deb --root-owner-group --build "$package_root" "$artifact"
+dpkg-deb --info "$artifact" >/dev/null
+echo "$artifact"

--- a/packaging/macos/build_dmg.sh
+++ b/packaging/macos/build_dmg.sh
@@ -2,16 +2,16 @@
 set -euo pipefail
 
 if [[ $# -ne 3 ]]; then
-  echo "usage: $0 <JARVIS.app> <version> <output-dir>" >&2
+  echo "usage: $0 <pyinstaller-dir> <version> <output-dir>" >&2
   exit 2
 fi
 
-app_path=$(cd "$(dirname "$1")" && pwd)/$(basename "$1")
+source_dir=$(cd "$(dirname "$1")" && pwd)/$(basename "$1")
 version=${2#v}
 output_dir=$(mkdir -p "$3" && cd "$3" && pwd)
 
-if [[ ! -d "$app_path/Contents/MacOS" ]]; then
-  echo "invalid app bundle: $app_path" >&2
+if [[ ! -x "$source_dir/JARVIS" ]]; then
+  echo "missing executable: $source_dir/JARVIS" >&2
   exit 1
 fi
 if [[ ! "$version" =~ ^[0-9][0-9A-Za-z.+-]*$ ]]; then
@@ -21,7 +21,39 @@ fi
 
 staging_dir=$(mktemp -d)
 trap 'rm -rf -- "$staging_dir"' EXIT
-cp -R "$app_path" "$staging_dir/JARVIS.app"
+app_path="$staging_dir/JARVIS.app"
+mkdir -p "$app_path/Contents/MacOS" "$app_path/Contents/Resources"
+cp -R "$source_dir" "$app_path/Contents/Resources/JARVIS"
+
+cat > "$app_path/Contents/MacOS/JARVIS" <<'EOF'
+#!/usr/bin/env sh
+contents_dir=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+exec "$contents_dir/Resources/JARVIS/JARVIS" "$@"
+EOF
+chmod 0755 "$app_path/Contents/MacOS/JARVIS"
+
+cat > "$app_path/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key><string>JARVIS</string>
+  <key>CFBundleExecutable</key><string>JARVIS</string>
+  <key>CFBundleIdentifier</key><string>com.pgagi.jarvis</string>
+  <key>CFBundleName</key><string>JARVIS</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>$version</string>
+  <key>NSMicrophoneUsageDescription</key><string>JARVIS uses the microphone for voice commands.</string>
+</dict>
+</plist>
+EOF
+
+JARVIS_CONFIG_DIR="$staging_dir/smoke-config" \
+  "$app_path/Contents/MacOS/JARVIS" --packaging-smoke-test
+rm -rf -- "$staging_dir/smoke-config"
+
+ditto -c -k --sequesterRsrc --keepParent \
+  "$app_path" "$output_dir/JARVIS-${version}-macos-app.zip"
 ln -s /Applications "$staging_dir/Applications"
 
 artifact="$output_dir/JARVIS-${version}-macos.dmg"

--- a/packaging/macos/build_dmg.sh
+++ b/packaging/macos/build_dmg.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <JARVIS.app> <version> <output-dir>" >&2
+  exit 2
+fi
+
+app_path=$(cd "$(dirname "$1")" && pwd)/$(basename "$1")
+version=${2#v}
+output_dir=$(mkdir -p "$3" && cd "$3" && pwd)
+
+if [[ ! -d "$app_path/Contents/MacOS" ]]; then
+  echo "invalid app bundle: $app_path" >&2
+  exit 1
+fi
+if [[ ! "$version" =~ ^[0-9][0-9A-Za-z.+-]*$ ]]; then
+  echo "invalid release version: $version" >&2
+  exit 1
+fi
+
+staging_dir=$(mktemp -d)
+trap 'rm -rf -- "$staging_dir"' EXIT
+cp -R "$app_path" "$staging_dir/JARVIS.app"
+ln -s /Applications "$staging_dir/Applications"
+
+artifact="$output_dir/JARVIS-${version}-macos.dmg"
+hdiutil create \
+  -volname "JARVIS ${version}" \
+  -srcfolder "$staging_dir" \
+  -ov \
+  -format UDZO \
+  "$artifact"
+echo "$artifact"

--- a/packaging/macos/build_standalone.sh
+++ b/packaging/macos/build_standalone.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PyInstaller attempts to re-sign every Mach-O file it collects. Chromium is a
+# nested signed app, so copying it after freezing preserves its valid layout.
+browser_dir=$(python - <<'PY'
+from pathlib import Path
+import playwright
+
+print(Path(playwright.__file__).parent / "driver" / "package" / ".local-browsers")
+PY
+)
+
+if [[ ! -d "$browser_dir" ]]; then
+  echo "Playwright browsers not found: $browser_dir" >&2
+  exit 1
+fi
+
+temporary_dir=$(mktemp -d)
+browser_backup="$temporary_dir/.local-browsers"
+
+restore_browser_cache() {
+  if [[ -d "$browser_backup" && ! -e "$browser_dir" ]]; then
+    mkdir -p "$(dirname "$browser_dir")"
+    mv "$browser_backup" "$browser_dir"
+  fi
+  rm -rf -- "$temporary_dir"
+}
+trap restore_browser_cache EXIT
+
+mv "$browser_dir" "$browser_backup"
+pyinstaller jarvis.spec --clean --noconfirm
+
+packaged_browser_dir="dist/JARVIS/_internal/playwright/driver/package/.local-browsers"
+mkdir -p "$(dirname "$packaged_browser_dir")"
+cp -R "$browser_backup" "$packaged_browser_dir"

--- a/packaging/windows/JARVIS.nsi
+++ b/packaging/windows/JARVIS.nsi
@@ -1,0 +1,56 @@
+Unicode True
+; Non-solid compression keeps memory use predictable for the bundled browser.
+SetCompressor lzma
+
+!ifndef APP_VERSION
+  !define APP_VERSION "0.0.0-dev"
+!endif
+!ifndef SOURCE_DIR
+  !error "SOURCE_DIR must point to the PyInstaller onedir output"
+!endif
+!ifndef OUTPUT_DIR
+  !define OUTPUT_DIR "."
+!endif
+
+!define PRODUCT_NAME "JARVIS"
+!define PRODUCT_PUBLISHER "PG-AGI"
+!define PRODUCT_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\JARVIS"
+
+Name "${PRODUCT_NAME} ${APP_VERSION}"
+OutFile "${OUTPUT_DIR}\JARVIS-${APP_VERSION}-windows-x64-setup.exe"
+InstallDir "$LOCALAPPDATA\Programs\JARVIS"
+InstallDirRegKey HKCU "${PRODUCT_KEY}" "InstallLocation"
+RequestExecutionLevel user
+
+Page directory
+Page instfiles
+UninstPage uninstConfirm
+UninstPage instfiles
+
+Section "Install"
+  SetOutPath "$INSTDIR"
+  ; Playwright's headed browser is used by JARVIS. The optional headless shell is
+  ; deliberately omitted when building from an older local browser cache.
+  File /r /x "chromium_headless_shell-*" "${SOURCE_DIR}\*"
+
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+  CreateDirectory "$SMPROGRAMS\JARVIS"
+  CreateShortcut "$SMPROGRAMS\JARVIS\JARVIS.lnk" "$INSTDIR\JARVIS.exe"
+  CreateShortcut "$SMPROGRAMS\JARVIS\Uninstall JARVIS.lnk" "$INSTDIR\Uninstall.exe"
+  CreateShortcut "$DESKTOP\JARVIS.lnk" "$INSTDIR\JARVIS.exe"
+
+  WriteRegStr HKCU "${PRODUCT_KEY}" "DisplayName" "${PRODUCT_NAME}"
+  WriteRegStr HKCU "${PRODUCT_KEY}" "DisplayVersion" "${APP_VERSION}"
+  WriteRegStr HKCU "${PRODUCT_KEY}" "Publisher" "${PRODUCT_PUBLISHER}"
+  WriteRegStr HKCU "${PRODUCT_KEY}" "InstallLocation" "$INSTDIR"
+  WriteRegStr HKCU "${PRODUCT_KEY}" "UninstallString" '"$INSTDIR\Uninstall.exe"'
+  WriteRegDWORD HKCU "${PRODUCT_KEY}" "NoModify" 1
+  WriteRegDWORD HKCU "${PRODUCT_KEY}" "NoRepair" 1
+SectionEnd
+
+Section "Uninstall"
+  Delete "$DESKTOP\JARVIS.lnk"
+  RMDir /r "$SMPROGRAMS\JARVIS"
+  RMDir /r "$INSTDIR"
+  DeleteRegKey HKCU "${PRODUCT_KEY}"
+SectionEnd

--- a/requirements-packaging.txt
+++ b/requirements-packaging.txt
@@ -1,0 +1,7 @@
+numpy==2.3.2
+playwright==1.54.0
+playwright-stealth==2.0.0
+PyAudio==0.2.14
+pyinstaller==6.15.0
+SpeechRecognition==3.14.3
+websocket-client==1.8.0

--- a/test_packaging.py
+++ b/test_packaging.py
@@ -1,0 +1,41 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import jarvis_launcher
+
+
+class PackagingRuntimeTests(unittest.TestCase):
+    def test_required_web_resources_resolve_from_source_tree(self):
+        self.assertTrue(os.path.isfile(jarvis_launcher.WEB_HTML))
+        self.assertTrue(os.path.isfile(jarvis_launcher.VISUAL_HTML))
+        self.assertTrue(
+            os.path.isfile(jarvis_launcher._resource_path("config.example.json"))
+        )
+
+    def test_config_is_bootstrapped_in_writable_user_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = os.path.join(temp_dir, "config.json")
+            with (
+                patch.object(jarvis_launcher, "_CONFIG_DIR", temp_dir),
+                patch.object(jarvis_launcher, "CONFIG_PATH", config_path),
+            ):
+                created_path = jarvis_launcher._ensure_config_file()
+                jarvis_launcher._save_token("a" * 24)
+
+                self.assertEqual(created_path, config_path)
+                with open(config_path, "r", encoding="utf-8") as config_file:
+                    config = json.load(config_file)
+                self.assertEqual(config["TOKEN"], "a" * 24)
+
+    def test_config_directory_can_be_overridden_for_automation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.dict(os.environ, {"JARVIS_CONFIG_DIR": temp_dir}):
+                self.assertEqual(jarvis_launcher._platform_config_dir(), temp_dir)
+                self.assertEqual(jarvis_launcher._runtime_config_dir(), temp_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Linked Issue

Closes #13

---

## Summary of Changes

- builds a single working PyInstaller application with bundled Python, web resources, the browser client, and Playwright Chromium
- creates actual native outputs: a per-user NSIS `.exe`, Debian/Ubuntu `.deb`, and macOS `.app` inside a `.dmg`
- adds pull-request/tag/manual GitHub Actions builds, executable smoke tests on all three OSes, artifact uploads, and versioned GitHub Releases
- moves credentials and the persistent browser profile to writable per-user storage while preserving source-checkout `config.json` compatibility
- adds packaging tests and focused build documentation

This submission does not commit generated installers or demo media to the source tree.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update
- [ ] Refactor / code cleanup
- [x] CI / tooling / config change

---

## Testing Performed

- [x] Tested on **Windows**
- [x] Tested on **macOS** (clean GitHub runner build, executable smoke test, `.app`/`.dmg`, and artifact upload passed)
- [x] Tested on **Linux** (clean GitHub runner build, executable smoke test, `.deb`, portable archive, and artifact upload passed)
- Platform tested on: Windows 10 x64
- Python version: 3.12.13

Steps and results:

1. `python -m unittest discover -v` -> 20 tests passed.
2. Built the final PyInstaller directory -> 646 files / 531.3 MB.
3. Ran `JARVIS.exe --packaging-smoke-test` -> writable config, browser-client import, resources, and bundled Chromium all passed.
4. Built the final NSIS installer -> 179.3 MB, SHA-256 `75F1B5A1ECC60C52E597CEF3E9ED87AD7528B41F77FB84C5509521D35AEB9F53`.
5. Performed a clean install to a non-default test directory; verified version `0.1.0`, registry entry, Start Menu shortcut, and desktop shortcut.
6. Ran the installed executable smoke test; it found Chromium inside the installed `_internal` directory.
7. Ran the uninstaller; verified the test program directory, registry entry, Start Menu folder, and desktop shortcut were all removed.
8. Parsed the workflow YAML, checked all shell scripts with `bash -n`, compiled Python sources, and ran `git diff --check`.
9. [Clean three-OS validation run](https://github.com/JulianaIan2025/toingg-jarvis/actions/runs/31776983161) - Windows, Linux, and macOS jobs all passed and uploaded native artifacts.

---

## Screenshots / Recordings

[24-second native installers demo (MP4, hosted as a separate release asset)](https://github.com/JulianaIan2025/toingg-jarvis/releases/download/bounty-13-demo-20260813/jarvis-native-installers-demo.mp4)

---

## Checklist

- [x] My code follows the project's style guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] I have commented non-obvious packaging/runtime logic
- [x] I have updated relevant documentation
- [x] My changes do not introduce new warnings or errors in local validation
- [x] I have tested this on at least one supported platform
- [x] I have not committed secrets, API keys, generated installers, or personal config files

/claim #13

