### PR TITLE
feat: add native packaging pipelines for Windows, Linux and macOS

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -1,0 +1,111 @@
+name: Build Native Packages
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller numpy sounddevice SpeechRecognition websocket-client rich playwright playwright-stealth requests
+
+      - name: Build executable
+        run: pyinstaller packaging/jarvis.spec
+
+      - name: Build installer (Inno Setup)
+        shell: pwsh
+        run: |
+          $iscc = (Get-ChildItem "C:\Program Files*\Inno Setup*" -Filter ISCC.exe -Recurse | Select-Object -First 1).FullName
+          & $iscc packaging/windows/installer.iss
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jarvis-windows
+          path: |
+            dist/*.exe
+            dist/installer/JARVIS-setup.exe
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev devscripts debhelper fakeroot
+          python -m pip install --upgrade pip
+          pip install pyinstaller numpy sounddevice SpeechRecognition websocket-client rich playwright playwright-stealth requests
+
+      - name: Build binary
+        run: pyinstaller packaging/jarvis.spec
+
+      - name: Build .deb package
+        run: bash packaging/linux/build-deb.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jarvis-linux
+          path: |
+            dist/*.deb
+            dist/jarvis-linux-*
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          brew install portaudio create-dmg
+          python -m pip install --upgrade pip
+          pip install pyinstaller numpy sounddevice SpeechRecognition websocket-client rich playwright playwright-stealth requests
+
+      - name: Build .app bundle and .dmg
+        run: |
+          pyinstaller packaging/jarvis.spec
+          hdiutil create -volname "JARVIS" -srcfolder dist/JARVIS.app -ov -format UDZO dist/JARVIS-macos.dmg
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jarvis-macos
+          path: dist/JARVIS-macos.dmg
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build-windows, build-linux, build-macos]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: artifacts
+
+      - name: Attach packages to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -204,7 +204,21 @@ python3 jarvis_launcher.py
 
 ## 🛠️ Installation
 
-### 1. Clone the repository
+### Option A — Native packages (recommended)
+
+Prebuilt installers are generated automatically by CI for every `v*` release tag:
+
+| Platform | Package |
+| --- | --- |
+| Windows | `JARVIS-setup.exe` (Inno Setup installer) |
+| Linux | `jarvis_<version>_amd64.deb` |
+| macOS | `JARVIS-macos.dmg` |
+
+Download them from the repository's [Releases](https://github.com/PG-AGI/toingg-jarvis/releases) page, or build them yourself with `pyinstaller packaging/jarvis.spec` (see `packaging/`).
+
+### Option B — From source
+
+#### 1. Clone the repository
 
 ```bash
 git clone https://github.com/PG-AGI/toingg-jarvis.git

--- a/packaging/jarvis.spec
+++ b/packaging/jarvis.spec
@@ -1,0 +1,66 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for building native JARVIS binaries on Windows, Linux and macOS."""
+
+import os
+
+block_cipher = None
+
+datas = [
+    ("jarvis_web.html", "."),
+    ("jarvis_visual.html", "."),
+    ("browserClient.py", "."),
+]
+
+a = Analysis(
+    ["jarvis_launcher.py"],
+    pathex=[os.path.abspath(".")],
+    binaries=[],
+    datas=datas,
+    hiddenimports=[
+        "native_file_manager",
+        "pipecat_gemini_tools",
+        "sounddevice",
+        "numpy",
+        "speech_recognition",
+        "websocket",
+        "rich",
+        "requests",
+    ],
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    cipher=block_cipher,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="JARVIS",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    name="JARVIS",
+)
+
+# macOS .app bundle (applies automatically when building on darwin)
+app = BUNDLE(
+    coll,
+    name="JARVIS.app",
+    icon=None,
+    bundle_identifier="com.pgagi.toingg-jarvis",
+)

--- a/packaging/linux/build-deb.sh
+++ b/packaging/linux/build-deb.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Builds a Debian .deb package from the PyInstaller output in dist/JARVIS/.
+set -euo pipefail
+
+VERSION="${1:-0.2.0}"
+PKGROOT="dist/jarvis-deb/jarvis_${VERSION}_amd64"
+DEB="dist/jarvis_${VERSION}_amd64.deb"
+
+mkdir -p "${PKGROOT}/opt/jarvis" "${PKGROOT}/usr/local/bin" "${PKGROOT}/DEBIAN"
+
+cp -r dist/JARVIS/. "${PKGROOT}/opt/jarvis/"
+
+ln -sf /opt/jarvis/JARVIS "${PKGROOT}/usr/local/bin/jarvis"
+
+cat > "${PKGROOT}/DEBIAN/control" <<EOF
+Package: jarvis
+Version: ${VERSION}
+Section: utils
+Priority: optional
+Architecture: amd64
+Depends: libportaudio2, libasound2
+Maintainer: PG-AGI <support@pg-agi.com>
+Description: Toingg JARVIS voice launcher
+ Wake-trigger voice assistant with browser slot-grid control.
+EOF
+
+cat > "${PKGROOT}/DEBIAN/postinst" <<'EOF'
+#!/bin/sh
+set -e
+# Chromium is required by Playwright at runtime; users may run:
+#   playwright install chromium
+exit 0
+EOF
+chmod 755 "${PKGROOT}/DEBIAN/postinst"
+
+dpkg-deb --build --root-owner-group "$(dirname "${PKGROOT}")"
+echo "Built ${DEB}"

--- a/packaging/windows/installer.iss
+++ b/packaging/windows/installer.iss
@@ -1,0 +1,33 @@
+; Inno Setup script for JARVIS (Windows installer)
+
+#define MyAppName "JARVIS"
+#define MyAppVersion "0.2.0"
+#define MyAppExeName "JARVIS.exe"
+
+[Setup]
+AppId={{8E4B7C2A-5D1F-4A9B-9C3E-TOINGGJARVIS}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+DefaultDirName={autopf}\{#MyAppName}
+DefaultGroupName={#MyAppName}
+OutputDir=..\..
+OutputBaseFilename=JARVIS-setup
+Compression=lzma2
+SolidCompression=yes
+ArchitecturesInstallIn64BitMode=x64compatible
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Files]
+Source: "..\..\dist\JARVIS\*"; DestDir: "{app}"; Flags: recursesubdirs ignoreversion
+
+[Icons]
+Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '')}}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #13

---

## Summary of Changes

- Add `.github/workflows/build-packages.yml`: CI pipeline producing native packages for all major OSes on `v*` tags (Windows Inno Setup installer, Linux `.deb`, macOS `.app` + `.dmg`) with automatic artifact upload and release attachment.
- Add `packaging/jarvis.spec`: PyInstaller spec bundling the HTML assets (`jarvis_web.html`, `jarvis_visual.html`, `browserClient.py`) and required hidden imports; produces a `JARVIS.app` bundle automatically on macOS builds.
- Add `packaging/linux/build-deb.sh`: packages the PyInstaller output into a Debian package with proper control/postinst files and a `/usr/local/bin/jarvis` symlink.
- Add `packaging/windows/installer.iss`: Inno Setup definition for the Windows one-click installer.
- Update README with an "Option A — Native packages" installation section pointing at releases.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI / tooling / config change

---

## Testing Performed

- YAML workflow validated with `js-yaml`
- `jarvis.spec` validated as Python (`ast.parse`)
- `build-deb.sh` shell syntax checked (`bash -n`)
- Full matrix build runs in CI on the first `v*` tag or manual dispatch
